### PR TITLE
AI Image Gen : refonte de l'outil et correction de trois fonctions mortes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ data/users.test.json
 # et ne doivent jamais partir dans l'historique.
 data/*.db*
 
+# Données runtime des modules : images générées, historiques et surtout
+# `secrets.json` (clés API). `module.json` reste versionné, lui, car c'est le
+# manifeste du module — d'où la séparation des deux.
+modules/*/data/
+
 # uploads
 /uploads
 .idea

--- a/app/(app)/m/[moduleName]/[[...path]]/module-page-loader.tsx
+++ b/app/(app)/m/[moduleName]/[[...path]]/module-page-loader.tsx
@@ -20,6 +20,10 @@ const MODULE_PAGES: Record<
       ssr: false,
       loading: LoadingSpinner,
     }),
+    library: dynamic(() => import("@/modules/ai-image-gen/pages/library"), {
+      ssr: false,
+      loading: LoadingSpinner,
+    }),
     settings: dynamic(() => import("@/modules/ai-image-gen/pages/settings"), {
       ssr: false,
       loading: LoadingSpinner,

--- a/app/api/modules/call-function/route.ts
+++ b/app/api/modules/call-function/route.ts
@@ -131,9 +131,21 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("Erreur lors de l'appel de fonction:", error);
-    return NextResponse.json(
-      { error: "Erreur lors de l'appel de fonction" },
-      { status: 500 }
-    );
+
+    // Le message vient de la fonction du module et porte l'information utile
+    // (« quota dépassé », « clé refusée »…). Le remplacer par un libellé
+    // générique laissait l'utilisateur sans piste.
+    const message =
+      error instanceof Error ? error.message : "Erreur lors de l'appel de fonction";
+
+    logDb.createLog({
+      level: "error",
+      action: "module.function" as LogAction,
+      message: `Échec de l'appel de fonction : ${message}`,
+      userId: session?.user?.id || undefined,
+      userEmail: session?.user?.email || undefined,
+    });
+
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
 }

--- a/components/ui/attachment.tsx
+++ b/components/ui/attachment.tsx
@@ -1,0 +1,204 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+const attachmentVariants = cva(
+  "group/attachment relative flex w-fit max-w-full min-w-0 shrink-0 flex-wrap rounded-xl border bg-card text-card-foreground transition-colors focus-within:ring-1 focus-within:ring-ring/50 has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed",
+  {
+    variants: {
+      size: {
+        default:
+          "gap-2 text-sm has-data-[slot=attachment-content]:px-2.5 has-data-[slot=attachment-content]:py-2 has-data-[slot=attachment-media]:p-2",
+        sm: "gap-2.5 text-xs has-data-[slot=attachment-content]:px-2 has-data-[slot=attachment-content]:py-1.5 has-data-[slot=attachment-media]:p-1.5",
+        xs: "gap-1.5 rounded-lg text-xs has-data-[slot=attachment-content]:px-1.5 has-data-[slot=attachment-content]:py-1 has-data-[slot=attachment-media]:p-1",
+      },
+      orientation: {
+        horizontal: "min-w-40 items-center",
+        vertical: "w-24 flex-col has-data-[slot=attachment-content]:w-30",
+      },
+    },
+  }
+)
+
+function Attachment({
+  className,
+  state = "done",
+  size = "default",
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof attachmentVariants> & {
+    state?: "idle" | "uploading" | "processing" | "error" | "done"
+  }) {
+  return (
+    <div
+      data-slot="attachment"
+      data-state={state}
+      data-size={size}
+      data-orientation={orientation}
+      className={cn(attachmentVariants({ size, orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+const attachmentMediaVariants = cva(
+  "relative flex aspect-square w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground group-data-[orientation=vertical]/attachment:w-full group-data-[size=sm]/attachment:w-8 group-data-[size=xs]/attachment:w-7 group-data-[size=xs]/attachment:rounded-md group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive group-data-[orientation=vertical]/attachment:*:data-[slot=spinner]:size-6! [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 group-data-[orientation=vertical]/attachment:[&_svg:not([class*='size-'])]:size-6 group-data-[size=xs]/attachment:[&_svg:not([class*='size-'])]:size-3.5",
+  {
+    variants: {
+      variant: {
+        icon: "",
+        image:
+          "opacity-60 group-data-[state=done]/attachment:opacity-100 group-data-[state=idle]/attachment:opacity-100 *:[img]:aspect-square *:[img]:w-full *:[img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "icon",
+    },
+  }
+)
+
+function AttachmentMedia({
+  className,
+  variant = "icon",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof attachmentMediaVariants>) {
+  return (
+    <div
+      data-slot="attachment-media"
+      data-variant={variant}
+      className={cn(attachmentMediaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-content"
+      className={cn(
+        "max-w-full min-w-0 flex-1 leading-tight group-data-[orientation=vertical]/attachment:px-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTitle({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-title"
+      className={cn(
+        "block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentDescription({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-description"
+      className={cn(
+        "mt-0.5 block min-w-0 truncate text-xs text-muted-foreground group-data-[state=error]/attachment:text-destructive/80",
+        "max-w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-actions"
+      className={cn(
+        "relative z-20 flex shrink-0 items-center group-data-[orientation=vertical]/attachment:absolute group-data-[orientation=vertical]/attachment:top-3 group-data-[orientation=vertical]/attachment:right-3 group-data-[orientation=vertical]/attachment:gap-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentAction({
+  className,
+  variant,
+  size = "icon-xs",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="attachment-action"
+      variant={variant ?? "ghost"}
+      size={size}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTrigger({
+  className,
+  asChild = false,
+  type,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="attachment-trigger"
+      type={asChild ? undefined : (type ?? "button")}
+      className={cn("absolute inset-0 z-10 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-group"
+      className={cn(
+        "flex min-w-0 scroll-fade-x snap-x snap-mandatory scroll-px-1 scrollbar-none gap-3 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Attachment,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentContent,
+  AttachmentTitle,
+  AttachmentDescription,
+  AttachmentActions,
+  AttachmentAction,
+  AttachmentTrigger,
+}

--- a/lib/modules/module-manager.api.ts
+++ b/lib/modules/module-manager.api.ts
@@ -623,13 +623,17 @@ class ApiModuleManagerImpl implements ModuleManager {
         return null;
       }
 
+      // Les erreurs levées par la fonction du module remontent volontairement :
+      // les renvoyer en `null` faisait passer un échec (clé API manquante,
+      // quota dépassé, contenu refusé) pour un succès sans résultat, et
+      // l'appelant n'avait aucun moyen de distinguer les deux.
       return await moduleExports[functionName](...args);
     } catch (error) {
       console.error(
         `Error calling ${functionName} on module ${moduleName}:`,
         error
       );
-      return null;
+      throw error;
     }
   }
 

--- a/modules/ai-image-gen/components/image-viewer.tsx
+++ b/modules/ai-image-gen/components/image-viewer.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Check,
+  Download,
+  ImageDown,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { VisuallyHidden } from "@/components/ui/visually-hidden";
+import { getModelSpec } from "../lib/models";
+import {
+  callModule,
+  downloadImage,
+  formatDuration,
+  imageUrl,
+  type HistoryItem,
+} from "../lib/client";
+
+/** Une image précise au sein d'une génération. */
+export interface Shot {
+  item: HistoryItem;
+  file: string;
+}
+
+interface ImageViewerProps {
+  shots: Shot[];
+  index: number | null;
+  onIndexChange: (index: number | null) => void;
+  /** Appelé après suppression ou copie en galerie, pour rafraîchir l'appelant. */
+  onMutate?: () => void;
+}
+
+export function ImageViewer({
+  shots,
+  index,
+  onIndexChange,
+  onMutate,
+}: ImageViewerProps) {
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const open = index !== null && index >= 0 && index < shots.length;
+  const shot = open ? shots[index] : null;
+
+  const go = useCallback(
+    (delta: number) => {
+      if (index === null || shots.length === 0) return;
+      // On boucle : arriver au bout d'un lot de 4 sans pouvoir revenir au
+      // début oblige à ressortir de la visionneuse pour rien.
+      onIndexChange((index + delta + shots.length) % shots.length);
+    },
+    [index, shots.length, onIndexChange]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "ArrowRight") go(1);
+      if (event.key === "ArrowLeft") go(-1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, go]);
+
+  useEffect(() => {
+    setCopied(false);
+  }, [index]);
+
+  if (!shot) return null;
+
+  const { item, file } = shot;
+  const spec = getModelSpec(item.model);
+  const alreadyInGallery = Boolean(item.savedToGallery?.[file]);
+
+  const handleCopyPrompt = async () => {
+    await navigator.clipboard.writeText(item.prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = async () => {
+    try {
+      await downloadImage(imageUrl(file), file);
+    } catch {
+      toast.error("Téléchargement impossible");
+    }
+  };
+
+  const handleSaveToGallery = async () => {
+    setBusy(true);
+    try {
+      const result = await callModule<{ fileName?: string }>(
+        "saveToGallery",
+        item.id,
+        file
+      );
+      toast.success(`Ajoutée à la galerie : ${result?.fileName ?? file}`);
+      onMutate?.();
+    } catch (error: any) {
+      toast.error(error?.message ?? "Copie impossible");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setBusy(true);
+    try {
+      await callModule("deleteImage", item.id, file);
+      toast.success("Image supprimée");
+      // La liste rétrécit : rester sur le même index afficherait la suivante,
+      // sauf si on était sur la dernière.
+      const next = shots.length <= 1 ? null : Math.min(index!, shots.length - 2);
+      onIndexChange(next);
+      onMutate?.();
+    } catch (error: any) {
+      toast.error(error?.message ?? "Suppression impossible");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => !next && onIndexChange(null)}
+    >
+      <DialogContent
+        showCloseButton
+        className="max-w-[min(96vw,1200px)] gap-0 overflow-hidden p-0 sm:max-w-[min(96vw,1200px)]"
+      >
+        <VisuallyHidden>
+          <DialogTitle>Image générée</DialogTitle>
+          <DialogDescription>{item.prompt}</DialogDescription>
+        </VisuallyHidden>
+
+        <div className="grid max-h-[90vh] grid-rows-[1fr_auto] md:grid-cols-[minmax(0,1fr)_320px] md:grid-rows-1">
+          {/* Visuel */}
+          <div className="relative flex min-h-0 items-center justify-center bg-muted/40 p-4">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl(file)}
+              alt={item.prompt}
+              className="max-h-[52vh] w-auto max-w-full rounded-lg object-contain shadow-sm md:max-h-[86vh]"
+            />
+
+            {shots.length > 1 && (
+              <>
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  aria-label="Image précédente"
+                  onClick={() => go(-1)}
+                  className="absolute left-3 h-9 w-9 rounded-full opacity-80 hover:opacity-100"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  aria-label="Image suivante"
+                  onClick={() => go(1)}
+                  className="absolute right-3 h-9 w-9 rounded-full opacity-80 hover:opacity-100"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+                <span className="absolute bottom-3 rounded-full bg-background/90 px-2.5 py-1 text-xs tabular-nums text-muted-foreground">
+                  {index! + 1} / {shots.length}
+                </span>
+              </>
+            )}
+          </div>
+
+          {/* Détail */}
+          <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto border-t p-5 md:border-l md:border-t-0">
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Prompt
+              </p>
+              <p className="text-sm leading-6">{item.prompt}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopyPrompt}
+                className="w-full gap-2"
+              >
+                {copied ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" />
+                    Copié
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5" />
+                    Copier le prompt
+                  </>
+                )}
+              </Button>
+            </div>
+
+            {item.revisedPrompt && item.revisedPrompt !== item.prompt && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Réécrit par le modèle
+                </p>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {item.revisedPrompt}
+                </p>
+              </div>
+            )}
+
+            {item.notes && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Notes appliquées
+                </p>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {item.notes}
+                </p>
+              </div>
+            )}
+
+            <Separator />
+
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <div className="col-span-2">
+                <dt className="text-xs text-muted-foreground">Modèle</dt>
+                <dd className="mt-0.5 font-medium">
+                  {spec?.label ?? item.model}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Taille</dt>
+                <dd className="mt-0.5 font-mono text-xs">{item.size}</dd>
+              </div>
+              {item.quality && (
+                <div>
+                  <dt className="text-xs text-muted-foreground">Qualité</dt>
+                  <dd className="mt-0.5 capitalize">{item.quality}</dd>
+                </div>
+              )}
+              {formatDuration(item.durationMs) && (
+                <div>
+                  <dt className="text-xs text-muted-foreground">Durée</dt>
+                  <dd className="mt-0.5 tabular-nums">
+                    {formatDuration(item.durationMs)}
+                  </dd>
+                </div>
+              )}
+              <div>
+                <dt className="text-xs text-muted-foreground">Date</dt>
+                <dd className="mt-0.5 text-xs tabular-nums">
+                  {new Date(item.createdAt).toLocaleString("fr-FR")}
+                </dd>
+              </div>
+            </dl>
+
+            {(item.usedReference || alreadyInGallery) && (
+              <div className="flex flex-wrap gap-1.5">
+                {item.usedReference && (
+                  <Badge variant="secondary">Image de référence</Badge>
+                )}
+                {alreadyInGallery && <Badge variant="secondary">En galerie</Badge>}
+              </div>
+            )}
+
+            <div className="mt-auto flex flex-col gap-2 pt-2">
+              <Button onClick={handleDownload} className="w-full gap-2">
+                <Download className="h-4 w-4" />
+                Télécharger
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleSaveToGallery}
+                disabled={busy || alreadyInGallery}
+                className="w-full gap-2"
+              >
+                <ImageDown className="h-4 w-4" />
+                {alreadyInGallery ? "Déjà en galerie" : "Ajouter à la galerie"}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={handleDelete}
+                disabled={busy}
+                className="w-full gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+                Supprimer
+              </Button>
+            </div>
+          </aside>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/modules/ai-image-gen/components/module-shell.tsx
+++ b/modules/ai-image-gen/components/module-shell.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * En-tête commun aux trois pages du module.
+ *
+ * Les pages sont des routes distinctes, pas des onglets d'un même composant :
+ * la barre est donc faite de liens. On garde l'apparence d'un sélecteur
+ * segmenté, qui dit mieux « trois vues d'un même outil » qu'une suite de
+ * boutons dispersés.
+ */
+
+const TABS = [
+  { href: "/m/ai-image-gen", label: "Studio", match: "" },
+  { href: "/m/ai-image-gen/library", label: "Bibliothèque", match: "library" },
+  { href: "/m/ai-image-gen/settings", label: "Configuration", match: "settings" },
+] as const;
+
+interface ModuleShellProps {
+  /** Segment courant : "", "library" ou "settings". */
+  current: string;
+  title: string;
+  description: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function ModuleShell({
+  current,
+  title,
+  description,
+  actions,
+  children,
+}: ModuleShellProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <Sparkles className="h-5 w-5" />
+            </span>
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+              <p className="text-sm text-muted-foreground">{description}</p>
+            </div>
+          </div>
+          {actions && (
+            <div className="flex shrink-0 items-center gap-2">{actions}</div>
+          )}
+        </div>
+
+        <nav
+          aria-label="Sections du module"
+          className="inline-flex w-fit items-center gap-1 rounded-lg bg-muted p-1"
+        >
+          {TABS.map((tab) => {
+            const active = tab.match === current;
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </header>
+
+      {children}
+    </div>
+  );
+}

--- a/modules/ai-image-gen/index.process.ts
+++ b/modules/ai-image-gen/index.process.ts
@@ -1,11 +1,15 @@
+import fs from "fs";
+import path from "path";
 import { ModuleHooks } from "../../types/modules";
+import { getAbsoluteUploadPath } from "../../lib/config";
 import {
   generateWithOpenAI,
   generateWithStability,
+  getModelSpec,
+  MODELS,
   type GenerateImageResult,
+  type ProviderId,
 } from "./lib/providers";
-import fs from "fs";
-import path from "path";
 
 let moduleSettings: Record<string, any> = {};
 
@@ -14,44 +18,123 @@ const DATA_DIR = path.join(MODULE_DIR, "data");
 const IMAGES_DIR = path.join(DATA_DIR, "images");
 const HISTORY_FILE = path.join(DATA_DIR, "history.json");
 
-// Ensure data directories exist
+/**
+ * Les clés API vivent ici et non dans `module.json` : ce dernier est versionné,
+ * donc y écrire une clé la ferait entrer dans l'historique git au prochain
+ * commit. `data/` est ignoré par git.
+ */
+const SECRETS_FILE = path.join(DATA_DIR, "secrets.json");
+
 function ensureDataDirs() {
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
   if (!fs.existsSync(IMAGES_DIR)) fs.mkdirSync(IMAGES_DIR, { recursive: true });
 }
 
-function getSettings(): Record<string, any> {
+function readJson<T>(file: string, fallback: T): T {
   try {
-    const configPath = path.join(MODULE_DIR, "module.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    return config.settings || moduleSettings;
+    if (!fs.existsSync(file)) return fallback;
+    return JSON.parse(fs.readFileSync(file, "utf-8")) as T;
   } catch {
-    return moduleSettings;
+    return fallback;
   }
 }
 
-// ─── History Management ──────────────────────────────────────────
+// ─── Réglages non sensibles ──────────────────────────────────────
+
+function getSettings(): Record<string, any> {
+  const config = readJson<{ settings?: Record<string, any> }>(
+    path.join(MODULE_DIR, "module.json"),
+    {}
+  );
+  return config.settings ?? moduleSettings;
+}
+
+// ─── Clés API ────────────────────────────────────────────────────
+
+interface Secrets {
+  openai_api_key?: string;
+  stability_api_key?: string;
+}
+
+/**
+ * Une variable d'environnement prime sur le fichier : en conteneur, la clé
+ * arrive par `env_file` et le volume de données peut être vierge.
+ */
+function getApiKey(provider: ProviderId): string {
+  const stored = readJson<Secrets>(SECRETS_FILE, {});
+  if (provider === "openai") {
+    return process.env.OPENAI_API_KEY || stored.openai_api_key || "";
+  }
+  return process.env.STABILITY_API_KEY || stored.stability_api_key || "";
+}
+
+/** Renseigne l'interface sur l'état des clés sans jamais les renvoyer. */
+export async function getSecretsStatus(): Promise<{
+  openai: { configured: boolean; fromEnv: boolean; hint: string };
+  stability: { configured: boolean; fromEnv: boolean; hint: string };
+}> {
+  const stored = readJson<Secrets>(SECRETS_FILE, {});
+  const describe = (envValue: string | undefined, fileValue: string | undefined) => {
+    const value = envValue || fileValue || "";
+    return {
+      configured: value.length > 0,
+      fromEnv: Boolean(envValue),
+      // Les 4 derniers caractères suffisent à reconnaître une clé sans l'exposer.
+      hint: value ? `••••••••${value.slice(-4)}` : "",
+    };
+  };
+  return {
+    openai: describe(process.env.OPENAI_API_KEY, stored.openai_api_key),
+    stability: describe(process.env.STABILITY_API_KEY, stored.stability_api_key),
+  };
+}
+
+export async function saveSecrets(
+  next: Secrets
+): Promise<{ success: boolean }> {
+  ensureDataDirs();
+  const current = readJson<Secrets>(SECRETS_FILE, {});
+  const merged: Secrets = { ...current };
+
+  // Une chaîne vide efface la clé ; `undefined` la laisse telle quelle, ce qui
+  // permet d'enregistrer un seul provider sans écraser l'autre.
+  for (const key of ["openai_api_key", "stability_api_key"] as const) {
+    if (next[key] !== undefined) {
+      if (next[key]) merged[key] = next[key];
+      else delete merged[key];
+    }
+  }
+
+  fs.writeFileSync(SECRETS_FILE, JSON.stringify(merged, null, 2), { mode: 0o600 });
+  return { success: true };
+}
+
+// ─── Historique ──────────────────────────────────────────────────
 
 export interface HistoryItem {
   id: string;
   prompt: string;
+  /** Prompt effectivement envoyé, notes comprises. */
+  finalPrompt: string;
   notes: string;
   provider: string;
   model: string;
   size: string;
+  quality?: string;
   count: number;
-  imageFiles: string[]; // filenames in data/images/
+  imageFiles: string[];
+  /** Prompt réécrit par le modèle, quand il en renvoie un. */
+  revisedPrompt?: string;
+  /** Fichiers copiés dans la galerie, indexés par nom de fichier local. */
+  savedToGallery?: Record<string, string>;
+  usedReference?: boolean;
+  favorite?: boolean;
+  durationMs?: number;
   createdAt: number;
 }
 
 function readHistory(): HistoryItem[] {
-  try {
-    if (!fs.existsSync(HISTORY_FILE)) return [];
-    const raw = fs.readFileSync(HISTORY_FILE, "utf-8");
-    return JSON.parse(raw);
-  } catch {
-    return [];
-  }
+  return readJson<HistoryItem[]>(HISTORY_FILE, []);
 }
 
 function writeHistory(items: HistoryItem[]) {
@@ -59,213 +142,326 @@ function writeHistory(items: HistoryItem[]) {
   fs.writeFileSync(HISTORY_FILE, JSON.stringify(items, null, 2));
 }
 
-export async function getHistory(limit: number = 50): Promise<HistoryItem[]> {
+export async function getHistory(limit = 200): Promise<HistoryItem[]> {
+  return readHistory().slice(0, limit);
+}
+
+/** Compteurs de la bibliothèque, calculés côté serveur pour éviter de rapatrier tout l'historique. */
+export async function getStats(): Promise<{
+  generations: number;
+  images: number;
+  favorites: number;
+  inGallery: number;
+  diskBytes: number;
+  byModel: { model: string; label: string; count: number }[];
+}> {
   const items = readHistory();
-  return items.slice(0, limit);
+  const byModel = new Map<string, number>();
+  let images = 0;
+  let inGallery = 0;
+
+  for (const item of items) {
+    images += item.imageFiles.length;
+    inGallery += Object.keys(item.savedToGallery ?? {}).length;
+    byModel.set(item.model, (byModel.get(item.model) ?? 0) + 1);
+  }
+
+  let diskBytes = 0;
+  if (fs.existsSync(IMAGES_DIR)) {
+    for (const file of fs.readdirSync(IMAGES_DIR)) {
+      try {
+        diskBytes += fs.statSync(path.join(IMAGES_DIR, file)).size;
+      } catch {
+        // Fichier disparu entre le listing et le stat : sans importance ici.
+      }
+    }
+  }
+
+  return {
+    generations: items.length,
+    images,
+    favorites: items.filter((i) => i.favorite).length,
+    inGallery,
+    diskBytes,
+    byModel: [...byModel.entries()]
+      .map(([model, count]) => ({
+        model,
+        label: getModelSpec(model)?.label ?? model,
+        count,
+      }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+function removeImageFiles(files: string[]) {
+  for (const file of files) {
+    // `basename` empêche qu'un nom forgé (« ../../.env ») sorte du dossier.
+    const target = path.join(IMAGES_DIR, path.basename(file));
+    if (fs.existsSync(target)) fs.unlinkSync(target);
+  }
 }
 
 export async function clearHistory(): Promise<{ success: boolean }> {
+  const items = readHistory();
+  for (const item of items) removeImageFiles(item.imageFiles);
   writeHistory([]);
-  // Delete all image files
-  if (fs.existsSync(IMAGES_DIR)) {
-    const files = fs.readdirSync(IMAGES_DIR);
-    for (const file of files) {
-      fs.unlinkSync(path.join(IMAGES_DIR, file));
-    }
-  }
   return { success: true };
 }
 
-export async function deleteHistoryItem(id: string): Promise<{ success: boolean }> {
+export async function deleteHistoryItem(
+  id: string
+): Promise<{ success: boolean }> {
   const items = readHistory();
   const item = items.find((i) => i.id === id);
-  if (item) {
-    // Delete associated image files
-    for (const file of item.imageFiles) {
-      const filePath = path.join(IMAGES_DIR, file);
-      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-    }
-  }
+  if (item) removeImageFiles(item.imageFiles);
   writeHistory(items.filter((i) => i.id !== id));
   return { success: true };
 }
 
-// ─── Image Generation ──────────────────────────────────────────
+/** Supprime une seule image d'un lot ; la génération disparaît si elle se vide. */
+export async function deleteImage(
+  id: string,
+  file: string
+): Promise<{ success: boolean }> {
+  const items = readHistory();
+  const item = items.find((i) => i.id === id);
+  if (!item) return { success: false };
+
+  removeImageFiles([file]);
+  item.imageFiles = item.imageFiles.filter((f) => f !== file);
+  if (item.savedToGallery) delete item.savedToGallery[file];
+
+  writeHistory(
+    item.imageFiles.length > 0 ? items : items.filter((i) => i.id !== id)
+  );
+  return { success: true };
+}
+
+export async function toggleFavorite(
+  id: string
+): Promise<{ success: boolean; favorite: boolean }> {
+  const items = readHistory();
+  const item = items.find((i) => i.id === id);
+  if (!item) return { success: false, favorite: false };
+  item.favorite = !item.favorite;
+  writeHistory(items);
+  return { success: true, favorite: item.favorite };
+}
+
+// ─── Copie vers la galerie ───────────────────────────────────────
+
+function randomSlug(length = 12): string {
+  const alphabet =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return out;
+}
+
+/**
+ * Copie une image générée dans le dossier d'upload, ce qui la fait apparaître
+ * dans la galerie de l'application au même titre qu'une capture ShareX.
+ */
+export async function saveToGallery(
+  id: string,
+  file: string
+): Promise<{ success: boolean; fileName?: string; error?: string }> {
+  const items = readHistory();
+  const item = items.find((i) => i.id === id);
+  if (!item) return { success: false, error: "Génération introuvable" };
+
+  const source = path.join(IMAGES_DIR, path.basename(file));
+  if (!fs.existsSync(source)) {
+    return { success: false, error: "Image introuvable sur le disque" };
+  }
+
+  const existing = item.savedToGallery?.[file];
+  if (existing) {
+    // Déjà copiée et toujours présente : ne pas dupliquer.
+    if (fs.existsSync(path.join(getAbsoluteUploadPath(), existing))) {
+      return { success: true, fileName: existing };
+    }
+  }
+
+  const fileName = `${randomSlug()}.png`;
+  fs.copyFileSync(source, path.join(getAbsoluteUploadPath(), fileName));
+
+  item.savedToGallery = { ...(item.savedToGallery ?? {}), [file]: fileName };
+  writeHistory(items);
+
+  return { success: true, fileName };
+}
+
+// ─── Génération ──────────────────────────────────────────────────
 
 export async function generateImage(
   prompt: string,
   options: {
-    provider?: "openai" | "stability";
     model?: string;
     size?: string;
+    quality?: string;
     n?: number;
     notes?: string;
     referenceImageB64?: string;
+    referenceMimeType?: string;
   } = {}
-): Promise<GenerateImageResult & { historyId: string }> {
-  const settings = getSettings();
-  const provider = options.provider || settings.provider || "openai";
-  const model = options.model || settings.default_model || "dall-e-3";
-  const size = options.size || settings.default_size || "1024x1024";
-  const count = options.n || 1;
-
-  // Build final prompt with notes preprompt
-  const notesPreprompt = options.notes || settings.notes_preprompt || "";
-  const finalPrompt = notesPreprompt
-    ? `${notesPreprompt}\n\n${prompt}`
-    : prompt;
-
-  let result: GenerateImageResult;
-
-  if (provider === "openai") {
-    const apiKey = settings.openai_api_key;
-    if (!apiKey) {
-      throw new Error(
-        "Clé API OpenAI non configurée. Allez dans Configuration pour la définir."
-      );
-    }
-
-    // DALL-E 3 only supports n=1, so make parallel calls for batch
-    if (model === "dall-e-3" && count > 1) {
-      const promises = Array.from({ length: count }, () =>
-        generateWithOpenAI({
-          prompt: finalPrompt,
-          provider: "openai",
-          model,
-          size,
-          n: 1,
-          apiKey,
-        })
-      );
-      const results = await Promise.all(promises);
-      result = {
-        images: results.flatMap((r) => r.images),
-      };
-    } else {
-      result = await generateWithOpenAI({
-        prompt: finalPrompt,
-        provider: "openai",
-        model,
-        size,
-        n: count,
-        apiKey,
-      });
-    }
-  } else if (provider === "stability") {
-    const apiKey = settings.stability_api_key;
-    if (!apiKey) {
-      throw new Error(
-        "Clé API Stability non configurée. Allez dans Configuration pour la définir."
-      );
-    }
-    result = await generateWithStability({
-      prompt: finalPrompt,
-      provider: "stability",
-      size,
-      n: count,
-      apiKey,
-    });
-  } else {
-    throw new Error(`Provider inconnu: ${provider}`);
+): Promise<GenerateImageResult & { historyId: string; savedToGallery: Record<string, string> }> {
+  if (!prompt?.trim()) {
+    throw new Error("Le prompt est vide.");
   }
 
-  // Save to history
+  const settings = getSettings();
+  const model = options.model || settings.default_model || "gpt-image-1";
+  const spec = getModelSpec(model);
+  if (!spec) {
+    throw new Error(`Modèle inconnu : ${model}`);
+  }
+
+  const provider = spec.provider;
+  const size = options.size || settings.default_size || spec.sizes[0];
+  const quality = options.quality || spec.qualities?.[0]?.value;
+  const count = Math.max(1, Math.min(options.n ?? 1, 10));
+
+  // Une référence fournie pour un modèle qui n'en gère pas serait ignorée en
+  // silence : autant le dire plutôt que de facturer une génération à côté.
+  // Ce contrôle passe avant celui de la clé : il ne coûte rien et pointe la
+  // vraie incohérence de la demande.
+  const reference = options.referenceImageB64;
+  if (reference && !spec.supportsReference) {
+    throw new Error(
+      `${spec.label} ne sait pas partir d'une image de référence. Choisissez GPT Image 1 ou retirez l'image.`
+    );
+  }
+
+  const apiKey = getApiKey(provider);
+  if (!apiKey) {
+    throw new Error(
+      provider === "openai"
+        ? "Aucune clé OpenAI enregistrée. Ouvrez la configuration du module pour en ajouter une."
+        : "Aucune clé Stability enregistrée. Ouvrez la configuration du module pour en ajouter une."
+    );
+  }
+
+  const notes = (options.notes ?? settings.notes_preprompt ?? "").trim();
+  const finalPrompt = notes ? `${notes}\n\n${prompt}` : prompt;
+
+  const startedAt = Date.now();
+  const result =
+    provider === "openai"
+      ? await generateWithOpenAI({
+          prompt: finalPrompt,
+          model,
+          size,
+          quality,
+          n: count,
+          apiKey,
+          referenceImageB64: reference,
+          referenceMimeType: options.referenceMimeType,
+        })
+      : await generateWithStability({
+          prompt: finalPrompt,
+          model,
+          size,
+          n: count,
+          apiKey,
+        });
+
+  if (result.images.length === 0) {
+    throw new Error("L'API n'a renvoyé aucune image.");
+  }
+
   ensureDataDirs();
-  const historyId = `gen-${Date.now()}`;
+  const historyId = `gen-${Date.now()}-${randomSlug(6)}`;
   const imageFiles: string[] = [];
 
   for (let i = 0; i < result.images.length; i++) {
-    const img = result.images[i];
-    if (img.b64) {
-      const filename = `${historyId}-${i}.png`;
-      const filePath = path.join(IMAGES_DIR, filename);
-      fs.writeFileSync(filePath, Buffer.from(img.b64, "base64"));
-      imageFiles.push(filename);
-    }
+    const fileName = `${historyId}-${i}.png`;
+    fs.writeFileSync(
+      path.join(IMAGES_DIR, fileName),
+      Buffer.from(result.images[i].b64, "base64")
+    );
+    imageFiles.push(fileName);
   }
 
-  const historyItem: HistoryItem = {
+  const item: HistoryItem = {
     id: historyId,
     prompt,
-    notes: notesPreprompt,
+    finalPrompt,
+    notes,
     provider,
     model,
     size,
-    count,
+    quality,
+    count: imageFiles.length,
     imageFiles,
+    revisedPrompt: result.images[0]?.revisedPrompt,
+    usedReference: Boolean(reference),
+    durationMs: Date.now() - startedAt,
     createdAt: Date.now(),
   };
 
   const history = readHistory();
-  history.unshift(historyItem);
-  // Keep last 100 items
-  if (history.length > 100) {
-    const removed = history.splice(100);
-    for (const old of removed) {
-      for (const f of old.imageFiles) {
-        const fp = path.join(IMAGES_DIR, f);
-        if (fs.existsSync(fp)) fs.unlinkSync(fp);
-      }
-    }
+  history.unshift(item);
+  if (history.length > 200) {
+    for (const old of history.splice(200)) removeImageFiles(old.imageFiles);
   }
   writeHistory(history);
 
-  return { ...result, historyId };
+  // Le réglage existait dans l'interface sans être lu nulle part : la copie
+  // vers la galerie ne se faisait jamais.
+  const savedToGallery: Record<string, string> = {};
+  if (settings.save_to_gallery) {
+    for (const file of imageFiles) {
+      const saved = await saveToGallery(historyId, file);
+      if (saved.success && saved.fileName) savedToGallery[file] = saved.fileName;
+    }
+  }
+
+  return { ...result, historyId, savedToGallery };
 }
 
-// ─── Connection Test ──────────────────────────────────────────
+// ─── Diagnostic ──────────────────────────────────────────────────
 
 export async function testConnection(
-  provider: "openai" | "stability"
+  provider: ProviderId
 ): Promise<{ success: boolean; message: string }> {
-  const settings = getSettings();
-
-  if (provider === "openai") {
-    const apiKey = settings.openai_api_key;
-    if (!apiKey)
-      return { success: false, message: "Clé API OpenAI non configurée" };
-    try {
-      const response = await fetch("https://api.openai.com/v1/models", {
-        headers: { Authorization: `Bearer ${apiKey}` },
-      });
-      if (response.ok)
-        return { success: true, message: "Connexion OpenAI réussie" };
-      return {
-        success: false,
-        message: `Erreur OpenAI: ${response.status}`,
-      };
-    } catch (error: any) {
-      return { success: false, message: `Erreur: ${error.message}` };
-    }
+  const apiKey = getApiKey(provider);
+  if (!apiKey) {
+    return { success: false, message: "Aucune clé enregistrée" };
   }
 
-  if (provider === "stability") {
-    const apiKey = settings.stability_api_key;
-    if (!apiKey)
-      return {
-        success: false,
-        message: "Clé API Stability non configurée",
-      };
-    try {
-      const response = await fetch(
-        "https://api.stability.ai/v1/engines/list",
-        { headers: { Authorization: `Bearer ${apiKey}` } }
-      );
-      if (response.ok)
-        return { success: true, message: "Connexion Stability AI réussie" };
-      return {
-        success: false,
-        message: `Erreur Stability: ${response.status}`,
-      };
-    } catch (error: any) {
-      return { success: false, message: `Erreur: ${error.message}` };
-    }
-  }
+  const endpoint =
+    provider === "openai"
+      ? "https://api.openai.com/v1/models"
+      : "https://api.stability.ai/v1/user/account";
 
-  return { success: false, message: `Provider inconnu: ${provider}` };
+  try {
+    const response = await fetch(endpoint, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (response.ok) {
+      return {
+        success: true,
+        message: provider === "openai" ? "Connexion OpenAI établie" : "Connexion Stability établie",
+      };
+    }
+    if (response.status === 401) {
+      return { success: false, message: "Clé refusée (401)" };
+    }
+    return { success: false, message: `Réponse inattendue : HTTP ${response.status}` };
+  } catch (error: any) {
+    return { success: false, message: `Réseau injoignable : ${error?.message ?? error}` };
+  }
 }
 
-// ─── Module Hooks ──────────────────────────────────────────
+/** Le catalogue de modèles vit côté serveur ; l'interface le récupère pour bâtir ses contrôles. */
+export async function getModels() {
+  return MODELS;
+}
+
+// ─── Cycle de vie ────────────────────────────────────────────────
 
 const moduleHooks: ModuleHooks = {
   onInit: () => {

--- a/modules/ai-image-gen/lib/client.ts
+++ b/modules/ai-image-gen/lib/client.ts
@@ -1,0 +1,174 @@
+/**
+ * Passerelle client → fonctions serveur du module, plus les quelques formats
+ * partagés par les trois pages.
+ */
+
+export interface HistoryItem {
+  id: string;
+  prompt: string;
+  finalPrompt: string;
+  notes: string;
+  provider: string;
+  model: string;
+  size: string;
+  quality?: string;
+  count: number;
+  imageFiles: string[];
+  revisedPrompt?: string;
+  savedToGallery?: Record<string, string>;
+  usedReference?: boolean;
+  favorite?: boolean;
+  durationMs?: number;
+  createdAt: number;
+}
+
+export interface ModuleStats {
+  generations: number;
+  images: number;
+  favorites: number;
+  inGallery: number;
+  diskBytes: number;
+  byModel: { model: string; label: string; count: number }[];
+}
+
+export interface SecretStatus {
+  configured: boolean;
+  fromEnv: boolean;
+  hint: string;
+}
+
+const MODULE_NAME = "ai-image-gen";
+
+/**
+ * Les fonctions du module répondent `{ success, data, error }`. On lève sur
+ * échec pour que les pages traitent erreur réseau et erreur métier au même
+ * endroit, avec un seul `catch`.
+ */
+export async function callModule<T = any>(
+  functionName: string,
+  ...args: unknown[]
+): Promise<T> {
+  const res = await fetch("/api/modules/call-function", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ moduleName: MODULE_NAME, functionName, args }),
+  });
+
+  let payload: any = null;
+  try {
+    payload = await res.json();
+  } catch {
+    throw new Error(`Réponse illisible du serveur (HTTP ${res.status})`);
+  }
+
+  if (!res.ok || payload?.success === false) {
+    throw new Error(payload?.error || `Échec de ${functionName}`);
+  }
+  return payload?.data as T;
+}
+
+export function imageUrl(file: string): string {
+  return `/api/modules/${MODULE_NAME}/data/images/${file}`;
+}
+
+export function timeAgo(ts: number): string {
+  const mins = Math.floor((Date.now() - ts) / 60000);
+  if (mins < 1) return "à l'instant";
+  if (mins < 60) return `il y a ${mins} min`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `il y a ${hours} h`;
+  const days = Math.floor(hours / 24);
+  if (days < 31) return `il y a ${days} j`;
+  return new Date(ts).toLocaleDateString("fr-FR");
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} o`;
+  const units = ["Ko", "Mo", "Go"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[unit]}`;
+}
+
+export function formatDuration(ms?: number): string | null {
+  if (!ms) return null;
+  return ms < 1000 ? `${ms} ms` : `${(ms / 1000).toFixed(1)} s`;
+}
+
+/** Fragments de style ajoutés au prompt en un clic. */
+export const PRESETS = [
+  {
+    label: "Anime",
+    fragment: "anime style, detailed illustration, vibrant colors",
+  },
+  {
+    label: "Photo",
+    fragment: "photorealistic, natural lighting, sharp focus, 50mm lens",
+  },
+  {
+    label: "Paysage",
+    fragment: "sweeping landscape, atmospheric lighting, wide angle",
+  },
+  {
+    label: "Portrait",
+    fragment: "portrait, studio lighting, shallow depth of field",
+  },
+  {
+    label: "Cyberpunk",
+    fragment: "cyberpunk, neon lights, rain-slick streets, cinematic",
+  },
+  {
+    label: "Fantasy",
+    fragment: "fantasy art, ethereal, dramatic lighting, painterly",
+  },
+  {
+    label: "Minimal",
+    fragment: "minimalist, flat design, generous negative space",
+  },
+  {
+    label: "3D",
+    fragment: "3D render, octane, soft global illumination",
+  },
+] as const;
+
+/**
+ * Télécharge une image depuis une URL du module. On passe par un blob plutôt
+ * que par `<a download>` sur l'URL directe : l'attribut est ignoré dès que la
+ * ressource est servie par une autre route, et le navigateur se contente
+ * d'ouvrir l'image.
+ */
+export async function downloadImage(url: string, fileName: string) {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = objectUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+/** Lit un fichier choisi par l'utilisateur en base64 nu (sans le préfixe `data:`). */
+export function readFileAsBase64(
+  file: File
+): Promise<{ b64: string; mimeType: string; dataUrl: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("Lecture du fichier impossible"));
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      resolve({
+        b64: dataUrl.split(",")[1] ?? "",
+        mimeType: file.type || "image/png",
+        dataUrl,
+      });
+    };
+    reader.readAsDataURL(file);
+  });
+}

--- a/modules/ai-image-gen/lib/models.ts
+++ b/modules/ai-image-gen/lib/models.ts
@@ -1,0 +1,79 @@
+/**
+ * Catalogue des modèles — données pures, sans dépendance serveur.
+ *
+ * Il est importé aussi bien par les adaptateurs API que par les pages du
+ * module : les contrôles de l'interface se construisent à partir d'ici, ce qui
+ * évite de proposer une taille ou un lot qu'un modèle refusera ensuite.
+ */
+
+export type ProviderId = "openai" | "stability";
+
+export interface ModelSpec {
+  id: string;
+  label: string;
+  provider: ProviderId;
+  description: string;
+  sizes: string[];
+  qualities?: { value: string; label: string }[];
+  /** Nombre maximum d'images qu'un seul appel API accepte. */
+  maxBatch: number;
+  /** Le modèle sait-il partir d'une image existante (endpoint /images/edits) ? */
+  supportsReference: boolean;
+  tags: string[];
+}
+
+export const MODELS: ModelSpec[] = [
+  {
+    id: "gpt-image-1",
+    label: "GPT Image 1",
+    provider: "openai",
+    description:
+      "Le modèle image courant d'OpenAI. Suit les consignes de près et sait retravailler une image existante.",
+    sizes: ["1024x1024", "1536x1024", "1024x1536"],
+    qualities: [
+      { value: "low", label: "Basse" },
+      { value: "medium", label: "Moyenne" },
+      { value: "high", label: "Haute" },
+    ],
+    maxBatch: 10,
+    supportsReference: true,
+    tags: ["Recommandé", "Image de référence"],
+  },
+  {
+    id: "dall-e-3",
+    label: "DALL-E 3",
+    provider: "openai",
+    description:
+      "Rendu très graphique. Réécrit systématiquement le prompt et ne produit qu'une image par appel.",
+    sizes: ["1024x1024", "1024x1792", "1792x1024"],
+    qualities: [
+      { value: "standard", label: "Standard" },
+      { value: "hd", label: "HD" },
+    ],
+    maxBatch: 1,
+    supportsReference: false,
+    tags: ["Portrait / paysage"],
+  },
+  {
+    id: "stable-diffusion-xl",
+    label: "Stable Diffusion XL",
+    provider: "stability",
+    description:
+      "Modèle ouvert hébergé par Stability AI. Demande une clé Stability distincte.",
+    sizes: ["1024x1024", "768x1024", "1024x768"],
+    maxBatch: 4,
+    supportsReference: false,
+    tags: ["Open source"],
+  },
+];
+
+export function getModelSpec(id: string): ModelSpec | undefined {
+  return MODELS.find((m) => m.id === id);
+}
+
+/** Ratio d'une taille « 1536x1024 », pour réserver la place du résultat avant qu'il arrive. */
+export function aspectRatioOf(size: string): number {
+  const [w, h] = size.split("x").map(Number);
+  if (!w || !h) return 1;
+  return w / h;
+}

--- a/modules/ai-image-gen/lib/providers.ts
+++ b/modules/ai-image-gen/lib/providers.ts
@@ -1,25 +1,77 @@
-export interface GenerateImageOptions {
-  prompt: string;
-  provider: "openai" | "stability";
-  model?: string;
-  size?: string;
-  n?: number;
-  apiKey: string;
-}
+/**
+ * Adaptateurs vers les API de génération d'images.
+ *
+ * Chaque provider expose la même signature et renvoie toujours du base64 :
+ * les URL temporaires d'OpenAI expirent en une heure, alors que le module
+ * archive les images sur disque. Recevoir directement les octets évite un
+ * aller-retour de téléchargement et une fenêtre pendant laquelle l'archivage
+ * peut échouer.
+ */
+
+import { MODELS, getModelSpec, type ProviderId } from "./models";
+
+export { MODELS, getModelSpec };
+export type { ProviderId, ModelSpec } from "./models";
 
 export interface GeneratedImage {
-  url?: string;
-  b64?: string;
+  b64: string;
+  /** Prompt réécrit par le modèle, quand il en renvoie un (gpt-image-1, DALL-E 3). */
+  revisedPrompt?: string;
 }
 
 export interface GenerateImageResult {
   images: GeneratedImage[];
 }
 
-export async function generateWithOpenAI(
+export interface GenerateImageOptions {
+  prompt: string;
+  model?: string;
+  size?: string;
+  quality?: string;
+  n?: number;
+  apiKey: string;
+  /** Image de départ en base64, sans le préfixe `data:`. Déclenche le mode édition. */
+  referenceImageB64?: string;
+  referenceMimeType?: string;
+}
+
+/**
+ * Les API renvoient leurs erreurs sous des formes différentes, et le message
+ * utile est souvent enfoui. On le remonte tel quel : « Erreur 400 » n'aide
+ * personne, « billing hard limit reached » se corrige tout de suite.
+ */
+async function readApiError(response: Response, fallback: string): Promise<string> {
+  let payload: any = null;
+  try {
+    payload = await response.json();
+  } catch {
+    return `${fallback} (HTTP ${response.status})`;
+  }
+  const message =
+    payload?.error?.message ??
+    payload?.message ??
+    (Array.isArray(payload?.errors) ? payload.errors.join(", ") : null);
+  return message ? String(message) : `${fallback} (HTTP ${response.status})`;
+}
+
+// ─── OpenAI ──────────────────────────────────────────────────────
+
+async function openAIGenerate(
   options: GenerateImageOptions
 ): Promise<GenerateImageResult> {
-  const { prompt, model = "dall-e-3", size = "1024x1024", n = 1, apiKey } = options;
+  const { prompt, model = "gpt-image-1", size, quality, n = 1, apiKey } = options;
+
+  const body: Record<string, unknown> = { model, prompt, n, size };
+
+  if (quality) {
+    body.quality = quality;
+  }
+
+  // gpt-image-1 renvoie toujours du base64 et rejette `response_format`.
+  // DALL-E 3 renvoie une URL par défaut : il faut le lui demander.
+  if (model !== "gpt-image-1") {
+    body.response_format = "b64_json";
+  }
 
   const response = await fetch("https://api.openai.com/v1/images/generations", {
     method: "POST",
@@ -27,36 +79,115 @@ export async function generateWithOpenAI(
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({
-      model,
-      prompt,
-      n: model === "dall-e-3" ? 1 : n,
-      size,
-      response_format: "b64_json",
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw new Error(
-      error?.error?.message || `OpenAI API error: ${response.status}`
-    );
+    throw new Error(await readApiError(response, "Erreur OpenAI"));
   }
 
   const data = await response.json();
   return {
-    images: data.data.map((item: any) => ({
-      b64: item.b64_json,
-      url: item.url,
-    })),
+    images: (data.data ?? [])
+      .filter((item: any) => item?.b64_json)
+      .map((item: any) => ({
+        b64: item.b64_json,
+        revisedPrompt: item.revised_prompt,
+      })),
   };
 }
+
+/**
+ * Retouche à partir d'une image existante. C'est un endpoint distinct, en
+ * multipart : l'image ne peut pas être passée en JSON.
+ */
+async function openAIEdit(
+  options: GenerateImageOptions
+): Promise<GenerateImageResult> {
+  const {
+    prompt,
+    model = "gpt-image-1",
+    size,
+    quality,
+    n = 1,
+    apiKey,
+    referenceImageB64,
+    referenceMimeType = "image/png",
+  } = options;
+
+  if (!referenceImageB64) {
+    throw new Error("Image de référence manquante");
+  }
+
+  const bytes = Buffer.from(referenceImageB64, "base64");
+  const extension = referenceMimeType.split("/")[1]?.split("+")[0] || "png";
+
+  const form = new FormData();
+  form.append("model", model);
+  form.append("prompt", prompt);
+  form.append("n", String(n));
+  if (size) form.append("size", size);
+  if (quality) form.append("quality", quality);
+  form.append(
+    "image",
+    new Blob([new Uint8Array(bytes)], { type: referenceMimeType }),
+    `reference.${extension}`
+  );
+
+  const response = await fetch("https://api.openai.com/v1/images/edits", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, "Erreur OpenAI"));
+  }
+
+  const data = await response.json();
+  return {
+    images: (data.data ?? [])
+      .filter((item: any) => item?.b64_json)
+      .map((item: any) => ({ b64: item.b64_json })),
+  };
+}
+
+export async function generateWithOpenAI(
+  options: GenerateImageOptions
+): Promise<GenerateImageResult> {
+  const spec = getModelSpec(options.model || "gpt-image-1");
+  const wantsReference = Boolean(options.referenceImageB64);
+
+  if (wantsReference && spec?.supportsReference) {
+    return openAIEdit(options);
+  }
+
+  const requested = options.n ?? 1;
+  const maxBatch = spec?.maxBatch ?? 1;
+
+  // DALL-E 3 refuse n > 1. Pour honorer un lot on parallélise les appels,
+  // sinon l'interface proposerait un choix que l'API rejetterait.
+  if (requested > maxBatch) {
+    const batches: Promise<GenerateImageResult>[] = [];
+    let remaining = requested;
+    while (remaining > 0) {
+      const take = Math.min(remaining, maxBatch);
+      batches.push(openAIGenerate({ ...options, n: take }));
+      remaining -= take;
+    }
+    const results = await Promise.all(batches);
+    return { images: results.flatMap((r) => r.images) };
+  }
+
+  return openAIGenerate(options);
+}
+
+// ─── Stability AI ────────────────────────────────────────────────
 
 export async function generateWithStability(
   options: GenerateImageOptions
 ): Promise<GenerateImageResult> {
-  const { prompt, size = "1024x1024", apiKey } = options;
-
+  const { prompt, size = "1024x1024", n = 1, apiKey } = options;
   const [width, height] = size.split("x").map(Number);
 
   const response = await fetch(
@@ -71,25 +202,22 @@ export async function generateWithStability(
       body: JSON.stringify({
         text_prompts: [{ text: prompt, weight: 1 }],
         cfg_scale: 7,
-        width: Math.min(width, 1024),
-        height: Math.min(height, 1024),
+        width: Math.min(width || 1024, 1024),
+        height: Math.min(height || 1024, 1024),
         steps: 30,
-        samples: 1,
+        samples: Math.min(n, 4),
       }),
     }
   );
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw new Error(
-      error?.message || `Stability API error: ${response.status}`
-    );
+    throw new Error(await readApiError(response, "Erreur Stability"));
   }
 
   const data = await response.json();
   return {
-    images: data.artifacts.map((artifact: any) => ({
-      b64: artifact.base64,
-    })),
+    images: (data.artifacts ?? [])
+      .filter((a: any) => a?.base64)
+      .map((a: any) => ({ b64: a.base64 })),
   };
 }

--- a/modules/ai-image-gen/module.json
+++ b/modules/ai-image-gen/module.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-image-gen",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Generez des images par intelligence artificielle",
   "author": "ShareX Manager",
   "enabled": true,
@@ -10,16 +10,16 @@
   "hasUI": false,
   "supportedFileTypes": [],
   "settings": {
-    "provider": "openai",
-    "openai_api_key": "",
-    "stability_api_key": "",
-    "default_model": "dall-e-3",
+    "default_model": "gpt-image-1",
     "default_size": "1024x1024",
-    "save_to_gallery": true,
+    "default_quality": "medium",
+    "default_count": 1,
+    "save_to_gallery": false,
     "notes_preprompt": ""
   },
   "pages": [
-    { "path": "", "title": "Generer", "component": "pages/generate.tsx" },
+    { "path": "", "title": "Studio", "component": "pages/generate.tsx" },
+    { "path": "library", "title": "Bibliotheque", "component": "pages/library.tsx" },
     { "path": "settings", "title": "Configuration", "component": "pages/settings.tsx" }
   ],
   "navItems": [

--- a/modules/ai-image-gen/pages/generate.tsx
+++ b/modules/ai-image-gen/pages/generate.tsx
@@ -1,8 +1,58 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Download,
+  ImageDown,
+  Images,
+  KeyRound,
+  Maximize2,
+  Paperclip,
+  RotateCcw,
+  Settings2,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupTextarea,
+} from "@/components/ui/input-group";
+import { Item, ItemContent, ItemDescription, ItemTitle } from "@/components/ui/item";
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+} from "@/components/ui/attachment";
 import {
   Select,
   SelectContent,
@@ -11,35 +61,24 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Sparkles,
-  Download,
-  Loader2,
-  ImageIcon,
-  Settings,
-  RotateCcw,
-  Upload,
-  X,
-  Trash2,
-  Clock,
-  Wand2,
-  Palette,
-  Mountain,
-  User,
-  Zap,
-  Camera,
-} from "lucide-react";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import type { ModuleConfig } from "@/types/modules";
-
-// ─── Types ──────────────────────────────────────────────────
+import { ModuleShell } from "../components/module-shell";
+import { ImageViewer, type Shot } from "../components/image-viewer";
+import { MODELS, aspectRatioOf, getModelSpec } from "../lib/models";
+import {
+  PRESETS,
+  callModule,
+  downloadImage,
+  imageUrl,
+  readFileAsBase64,
+  type HistoryItem,
+  type SecretStatus,
+} from "../lib/client";
 
 interface GeneratePageProps {
   moduleName: string;
@@ -47,647 +86,671 @@ interface GeneratePageProps {
   settings: Record<string, any>;
 }
 
-interface HistoryItem {
-  id: string;
-  prompt: string;
-  notes: string;
-  provider: string;
-  model: string;
-  size: string;
-  count: number;
-  imageFiles: string[];
-  createdAt: number;
+interface Reference {
+  b64: string;
+  mimeType: string;
+  dataUrl: string;
+  name: string;
+  size: number;
 }
 
-interface SessionImage {
-  b64?: string;
-  url?: string;
-  file?: string;
-}
-
-// ─── Constants ──────────────────────────────────────────────
-
-const PRESETS = [
-  { label: "Anime", icon: Sparkles, prompt: "anime style, detailed illustration, vibrant colors, high quality" },
-  { label: "Paysage", icon: Mountain, prompt: "landscape, scenic view, atmospheric lighting, detailed environment, 8k" },
-  { label: "Portrait", icon: User, prompt: "portrait, detailed face, studio lighting, professional photography" },
-  { label: "Cyberpunk", icon: Zap, prompt: "cyberpunk, neon lights, futuristic city, rain, dark atmosphere, cinematic" },
-  { label: "Fantasy", icon: Wand2, prompt: "fantasy art, magical, ethereal, detailed illustration, dramatic lighting" },
-  { label: "Réaliste", icon: Camera, prompt: "photorealistic, 8k, ultra high detail, natural lighting, sharp focus" },
-];
-
-const MODELS: Record<string, { label: string; provider: string; sizes: string[]; color: string; tags: string[] }> = {
-  "dall-e-3": {
-    label: "DALL-E 3",
-    provider: "openai",
-    sizes: ["1024x1024", "1024x1792", "1792x1024"],
-    color: "from-emerald-500 to-teal-600",
-    tags: ["Haute Qualité", "Créatif"],
-  },
-  "dall-e-2": {
-    label: "DALL-E 2",
-    provider: "openai",
-    sizes: ["256x256", "512x512", "1024x1024"],
-    color: "from-blue-500 to-cyan-600",
-    tags: ["Rapide", "Variations"],
-  },
-  "stable-diffusion-xl": {
-    label: "SDXL",
-    provider: "stability",
-    sizes: ["1024x1024", "768x1024", "1024x768"],
-    color: "from-violet-500 to-purple-600",
-    tags: ["Open Source", "Personnalisable"],
-  },
-};
-
-const SHOWCASE = [
-  { title: "Anime Portrait", gradient: "from-pink-500/20 to-purple-600/20", border: "border-pink-500/30" },
-  { title: "Paysage Fantasy", gradient: "from-emerald-500/20 to-cyan-600/20", border: "border-emerald-500/30" },
-  { title: "Cyberpunk City", gradient: "from-violet-500/20 to-fuchsia-600/20", border: "border-violet-500/30" },
-  { title: "Nature Réaliste", gradient: "from-amber-500/20 to-orange-600/20", border: "border-amber-500/30" },
-];
-
-// ─── Helper ──────────────────────────────────────────────────
-
-async function callModule(fn: string, ...args: any[]) {
-  const res = await fetch("/api/modules/call-function", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      moduleName: "ai-image-gen",
-      functionName: fn,
-      args,
-    }),
-  });
-  return res.json();
-}
-
-function imageUrl(file: string) {
-  return `/api/modules/ai-image-gen/data/images/${file}`;
-}
-
-function timeAgo(ts: number) {
-  const diff = Date.now() - ts;
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "À l'instant";
-  if (mins < 60) return `Il y a ${mins}min`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `Il y a ${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `Il y a ${days}j`;
-}
-
-// ─── Component ──────────────────────────────────────────────
+const COUNT_CHOICES = [1, 2, 4] as const;
 
 export default function GeneratePage({ settings }: GeneratePageProps) {
-  // Form state
+  // ─── Composition ────────────────────────────────────────────
   const [prompt, setPrompt] = useState("");
-  const [model, setModel] = useState(settings.default_model || "dall-e-3");
-  const [size, setSize] = useState(settings.default_size || "1024x1024");
-  const [count, setCount] = useState(1);
-  const [notes, setNotes] = useState(settings.notes_preprompt || "");
-  const [referenceImage, setReferenceImage] = useState<string | null>(null);
-  const refInputRef = useRef<HTMLInputElement>(null);
+  const [model, setModel] = useState<string>(
+    settings.default_model || "gpt-image-1"
+  );
+  const [size, setSize] = useState<string>(settings.default_size || "1024x1024");
+  const [quality, setQuality] = useState<string>(
+    settings.default_quality || "medium"
+  );
+  const [count, setCount] = useState<number>(settings.default_count || 1);
+  const [notes, setNotes] = useState<string>(settings.notes_preprompt || "");
+  const [reference, setReference] = useState<Reference | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Generation state
+  // ─── Exécution ──────────────────────────────────────────────
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sessionImages, setSessionImages] = useState<SessionImage[]>([]);
+  const [result, setResult] = useState<HistoryItem | null>(null);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
 
-  // History state
-  const [history, setHistory] = useState<HistoryItem[]>([]);
-  const [historyLoading, setHistoryLoading] = useState(true);
-  const [selectedHistory, setSelectedHistory] = useState<HistoryItem | null>(null);
+  // ─── Contexte ───────────────────────────────────────────────
+  const [recent, setRecent] = useState<HistoryItem[]>([]);
+  const [keys, setKeys] = useState<Record<string, SecretStatus> | null>(null);
 
-  // Derived
-  const modelInfo = MODELS[model];
-  const provider = modelInfo?.provider || "openai";
-  const availableSizes = modelInfo?.sizes || ["1024x1024"];
+  const spec = getModelSpec(model) ?? MODELS[0];
+  const ratio = aspectRatioOf(size);
 
-  // Load history on mount
-  useEffect(() => {
-    setHistoryLoading(true);
-    callModule("getHistory", 50)
-      .then((res) => {
-        if (res.success && res.data) setHistory(res.data);
-      })
-      .catch(() => {})
-      .finally(() => setHistoryLoading(false));
+  const providerReady = keys
+    ? Boolean(keys[spec.provider]?.configured)
+    : true; // Tant que l'état des clés n'est pas connu, on n'alarme pas.
+
+  const refreshHistory = useCallback(() => {
+    callModule<HistoryItem[]>("getHistory", 12)
+      .then(setRecent)
+      .catch(() => setRecent([]));
   }, []);
 
-  // Reset size when model changes
   useEffect(() => {
-    const sizes = MODELS[model]?.sizes || [];
-    if (!sizes.includes(size)) {
-      setSize(sizes[0] || "1024x1024");
-    }
-  }, [model, size]);
+    refreshHistory();
+    callModule<Record<string, SecretStatus>>("getSecretsStatus")
+      .then(setKeys)
+      .catch(() => setKeys(null));
+  }, [refreshHistory]);
 
-  // ─── Handlers ─────────────────────────────────────────────
+  // Chaque modèle a ses propres tailles et paliers de qualité : garder une
+  // valeur devenue invalide provoquerait un rejet côté API.
+  useEffect(() => {
+    if (!spec.sizes.includes(size)) setSize(spec.sizes[0]);
+    if (spec.qualities && !spec.qualities.some((q) => q.value === quality)) {
+      setQuality(spec.qualities[0].value);
+    }
+  }, [spec, size, quality]);
+
+  // Une référence chargée puis un changement de modèle qui ne la gère pas :
+  // on la retire plutôt que de laisser une pièce jointe sans effet.
+  useEffect(() => {
+    if (reference && !spec.supportsReference) {
+      setReference(null);
+      toast.info(`${spec.label} ne gère pas l'image de référence, elle a été retirée.`);
+    }
+  }, [spec, reference]);
+
+  const shots: Shot[] = useMemo(
+    () => (result ? result.imageFiles.map((file) => ({ item: result, file })) : []),
+    [result]
+  );
+
+  // ─── Actions ────────────────────────────────────────────────
 
   const handleGenerate = useCallback(async () => {
-    if (!prompt.trim()) return;
+    if (!prompt.trim() || loading) return;
     setLoading(true);
     setError(null);
-    setSelectedHistory(null);
 
     try {
-      const result = await callModule("generateImage", prompt, {
-        provider,
-        model,
-        size,
-        n: count,
-        notes: notes || undefined,
-        referenceImageB64: referenceImage || undefined,
-      });
-
-      if (!result.success) {
-        throw new Error(result.error || "Erreur lors de la génération");
-      }
-
-      const images: SessionImage[] = (result.data?.images || []).map(
-        (img: any, i: number) => ({
-          b64: img.b64,
-          url: img.url,
-          file: result.data?.historyId
-            ? `${result.data.historyId}-${i}.png`
-            : undefined,
-        })
+      const response = await callModule<{ historyId: string }>(
+        "generateImage",
+        prompt,
+        {
+          model,
+          size,
+          quality: spec.qualities ? quality : undefined,
+          n: count,
+          notes: notes || undefined,
+          referenceImageB64: reference?.b64,
+          referenceMimeType: reference?.mimeType,
+        }
       );
-      setSessionImages(images);
 
-      // Refresh history
-      const histRes = await callModule("getHistory", 50);
-      if (histRes.success && histRes.data) setHistory(histRes.data);
+      // On relit l'historique plutôt que de reconstruire l'objet côté client :
+      // le serveur est seul à connaître les copies en galerie et la durée.
+      const history = await callModule<HistoryItem[]>("getHistory", 12);
+      setRecent(history);
+      const fresh = history.find((h) => h.id === response.historyId);
+      if (fresh) setResult(fresh);
+      toast.success(
+        fresh && fresh.count > 1
+          ? `${fresh.count} images générées`
+          : "Image générée"
+      );
     } catch (err: any) {
-      setError(err.message || "Erreur inattendue");
+      setError(err?.message ?? "Erreur inattendue");
     } finally {
       setLoading(false);
     }
-  }, [prompt, provider, model, size, count, notes, referenceImage]);
+  }, [prompt, loading, model, size, quality, spec, count, notes, reference]);
 
-  const handleReset = useCallback(() => {
-    setPrompt("");
-    setError(null);
-    setSessionImages([]);
-    setSelectedHistory(null);
-    setReferenceImage(null);
-    setModel(settings.default_model || "dall-e-3");
-    setSize(settings.default_size || "1024x1024");
-    setCount(1);
-    setNotes(settings.notes_preprompt || "");
-  }, [settings]);
-
-  const handlePreset = useCallback((presetPrompt: string) => {
-    setPrompt((prev) =>
-      prev ? `${prev}, ${presetPrompt}` : presetPrompt
-    );
-  }, []);
-
-  const handleDownload = useCallback((src: string, index: number) => {
-    const link = document.createElement("a");
-    link.href = src;
-    link.download = `ai-gen-${Date.now()}-${index}.png`;
-    link.click();
-  }, []);
-
-  const handleRefUpload = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
+  const handleReferencePick = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = ""; // Permet de resélectionner le même fichier.
       if (!file) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        const b64 = (reader.result as string).split(",")[1];
-        setReferenceImage(b64);
-      };
-      reader.readAsDataURL(file);
+
+      if (!file.type.startsWith("image/")) {
+        toast.error("Le fichier doit être une image");
+        return;
+      }
+      try {
+        const { b64, mimeType, dataUrl } = await readFileAsBase64(file);
+        setReference({ b64, mimeType, dataUrl, name: file.name, size: file.size });
+      } catch {
+        toast.error("Lecture de l'image impossible");
+      }
     },
     []
   );
 
-  const handleHistoryClick = useCallback((item: HistoryItem) => {
-    setSelectedHistory(item);
-    setSessionImages(
-      item.imageFiles.map((f) => ({ file: f }))
-    );
+  const handleReset = useCallback(() => {
+    setPrompt("");
+    setError(null);
+    setResult(null);
+    setReference(null);
+    setModel(settings.default_model || "gpt-image-1");
+    setCount(settings.default_count || 1);
+    setNotes(settings.notes_preprompt || "");
+  }, [settings]);
+
+  const applyPreset = useCallback((fragment: string) => {
+    setPrompt((prev) => {
+      if (prev.includes(fragment)) return prev;
+      return prev.trim() ? `${prev.trim()}, ${fragment}` : fragment;
+    });
+  }, []);
+
+  const reuse = useCallback((item: HistoryItem) => {
     setPrompt(item.prompt);
+    setModel(item.model);
+    setSize(item.size);
+    if (item.quality) setQuality(item.quality);
+    setResult(item);
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
-  const handleClearHistory = useCallback(async () => {
-    await callModule("clearHistory");
-    setHistory([]);
-    setSelectedHistory(null);
-  }, []);
+  const saveShotToGallery = useCallback(
+    async (item: HistoryItem, file: string) => {
+      try {
+        const res = await callModule<{ fileName?: string }>(
+          "saveToGallery",
+          item.id,
+          file
+        );
+        toast.success(`Ajoutée à la galerie : ${res?.fileName}`);
+        refreshHistory();
+      } catch (err: any) {
+        toast.error(err?.message ?? "Copie impossible");
+      }
+    },
+    [refreshHistory]
+  );
 
-  // ─── Render helpers ───────────────────────────────────────
-
-  const displayImages =
-    sessionImages.length > 0
-      ? sessionImages
-      : selectedHistory
-        ? selectedHistory.imageFiles.map((f) => ({ file: f }))
-        : [];
-
-  function getImageSrc(img: SessionImage) {
-    if (img.b64) return `data:image/png;base64,${img.b64}`;
-    if (img.file) return imageUrl(img.file);
-    return img.url || "";
-  }
-
-  // ─── JSX ──────────────────────────────────────────────────
+  // ─── Rendu ──────────────────────────────────────────────────
 
   return (
-    <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
-            <Sparkles className="h-7 w-7 text-primary" />
-            AI Image Generation
-          </h1>
-          <p className="text-muted-foreground text-sm">
-            Générez des images à partir de descriptions textuelles
-          </p>
-        </div>
-        <Button variant="outline" size="sm" asChild>
-          <a href="/m/ai-image-gen/settings">
-            <Settings className="mr-2 h-4 w-4" />
-            Paramètres
-          </a>
+    <ModuleShell
+      current=""
+      title="Studio"
+      description="Décrivez une image, ajustez les réglages, générez."
+      actions={
+        <Button variant="outline" size="sm" asChild className="gap-2">
+          <Link href="/m/ai-image-gen/library">
+            <Images className="h-4 w-4" />
+            Bibliothèque
+          </Link>
         </Button>
-      </div>
+      }
+    >
+      {keys && !providerReady && (
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-amber-500/40 bg-amber-500/5 px-4 py-3">
+          <KeyRound className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
+          <p className="min-w-0 flex-1 text-sm">
+            Aucune clé{" "}
+            {spec.provider === "openai" ? "OpenAI" : "Stability"} enregistrée —
+            la génération échouera tant qu&apos;elle manque.
+          </p>
+          <Button size="sm" variant="outline" asChild className="gap-1.5">
+            <Link href="/m/ai-image-gen/settings">
+              Configurer
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        </div>
+      )}
 
-      {/* Main 3-column layout */}
-      <div className="grid gap-4 lg:grid-cols-[220px_1fr_280px]">
-        {/* ─── LEFT: History ─────────────────────── */}
-        <Card className="hidden lg:flex flex-col max-h-[calc(100vh-180px)]">
-          <CardHeader className="pb-2 flex-row items-center justify-between space-y-0">
-            <CardTitle className="text-sm flex items-center gap-1.5">
-              <Clock className="h-4 w-4" />
-              Historique
-            </CardTitle>
-            {history.length > 0 && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6"
-                onClick={handleClearHistory}
-                title="Effacer l'historique"
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent className="flex-1 overflow-hidden p-2">
-            <ScrollArea className="h-full">
-              {historyLoading ? (
-                <div className="flex justify-center py-4">
-                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                </div>
-              ) : history.length === 0 ? (
-                <p className="text-xs text-muted-foreground text-center py-4">
-                  Pas encore de génération
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {history.map((item) => (
-                    <button
-                      key={item.id}
-                      onClick={() => handleHistoryClick(item)}
-                      className={`w-full text-left rounded-lg border p-2 transition-colors hover:bg-accent ${
-                        selectedHistory?.id === item.id
-                          ? "border-primary bg-accent"
-                          : "border-transparent"
-                      }`}
-                    >
-                      {item.imageFiles[0] && (
-                        /* eslint-disable-next-line @next/next/no-img-element */
-                        <img
-                          src={imageUrl(item.imageFiles[0])}
-                          alt=""
-                          className="w-full aspect-square rounded-md object-cover mb-1.5"
-                        />
-                      )}
-                      <p className="text-xs line-clamp-2">{item.prompt}</p>
-                      <p className="text-[10px] text-muted-foreground mt-0.5">
-                        {timeAgo(item.createdAt)}
-                      </p>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </ScrollArea>
-          </CardContent>
-        </Card>
-
-        {/* ─── CENTER: Prompt + Results ──────────── */}
-        <div className="space-y-4">
-          {/* Prompt */}
-          <Card>
-            <CardContent className="pt-4 space-y-3">
-              <Textarea
-                placeholder="Décrivez l'image que vous souhaitez générer..."
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+        {/* ─── Colonne principale ─────────────────────────── */}
+        <div className="flex min-w-0 flex-col gap-5">
+          <div className="space-y-3">
+            <InputGroup>
+              <InputGroupTextarea
+                placeholder="Un phare isolé dans la brume au lever du jour, lumière rasante…"
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
-                rows={3}
-                className="resize-none text-sm border-muted-foreground/20"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
                     e.preventDefault();
                     handleGenerate();
                   }
                 }}
+                className="min-h-[112px] text-sm"
               />
-
-              {/* Presets */}
-              <div className="flex flex-wrap gap-1.5">
-                {PRESETS.map((p) => (
-                  <button
-                    key={p.label}
-                    onClick={() => handlePreset(p.prompt)}
-                    className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent hover:border-primary/50"
+              <InputGroupAddon align="block-end" className="justify-between">
+                <span className="hidden items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+                  <KbdGroup>
+                    <Kbd>Ctrl</Kbd>
+                    <Kbd>↵</Kbd>
+                  </KbdGroup>
+                  pour générer
+                </span>
+                <div className="ml-auto flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleReset}
+                    disabled={loading}
+                    className="gap-1.5"
                   >
-                    <p.icon className="h-3 w-3" />
-                    {p.label}
-                  </button>
-                ))}
-              </div>
-
-              {/* Actions */}
-              <div className="flex gap-2">
-                <Button
-                  onClick={handleGenerate}
-                  disabled={loading || !prompt.trim()}
-                  className="flex-1"
-                >
-                  {loading ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Génération...
-                    </>
-                  ) : (
-                    <>
-                      <Sparkles className="mr-2 h-4 w-4" />
-                      Générer{count > 1 ? ` (${count})` : ""}
-                    </>
-                  )}
-                </Button>
-                <Button variant="outline" onClick={handleReset}>
-                  <RotateCcw className="mr-2 h-4 w-4" />
-                  Réinitialiser
-                </Button>
-              </div>
-
-              {error && (
-                <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                  {error}
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Réinitialiser
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleGenerate}
+                    disabled={loading || !prompt.trim()}
+                    className="gap-1.5"
+                  >
+                    {loading ? (
+                      <Spinner className="h-3.5 w-3.5" />
+                    ) : (
+                      <Sparkles className="h-3.5 w-3.5" />
+                    )}
+                    {loading
+                      ? "Génération…"
+                      : `Générer${count > 1 ? ` ×${count}` : ""}`}
+                  </Button>
                 </div>
-              )}
-            </CardContent>
-          </Card>
+              </InputGroupAddon>
+            </InputGroup>
 
-          {/* Results or Showcase */}
-          {displayImages.length > 0 ? (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm">
-                  Résultats
-                  {selectedHistory && (
-                    <span className="font-normal text-muted-foreground ml-2">
-                      — {timeAgo(selectedHistory.createdAt)}
-                    </span>
-                  )}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className={`grid gap-3 ${displayImages.length === 1 ? "grid-cols-1 max-w-lg mx-auto" : "grid-cols-2"}`}>
-                  {displayImages.map((img, i) => (
-                    <div
-                      key={i}
-                      className="group relative overflow-hidden rounded-lg border bg-muted"
+            <div className="flex flex-wrap gap-1.5">
+              {PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => applyPreset(preset.fragment)}
+                  className="rounded-full border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent hover:text-foreground"
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="text-sm font-medium text-destructive">
+                  La génération a échoué
+                </p>
+                {/* Le message vient tel quel de l'API : c'est lui qui indique
+                    s'il s'agit d'un quota, d'un refus de contenu ou d'une clé. */}
+                <p className="text-sm break-words text-destructive/90">{error}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Résultats */}
+          {loading ? (
+            <div
+              className={cn(
+                "grid gap-3",
+                count > 1 ? "grid-cols-2" : "grid-cols-1"
+              )}
+            >
+              {Array.from({ length: count }).map((_, i) => (
+                // La place du résultat est réservée au bon ratio dès le départ :
+                // la page ne saute pas quand les images arrivent.
+                <Skeleton
+                  key={i}
+                  className="w-full rounded-xl"
+                  style={{ aspectRatio: ratio }}
+                />
+              ))}
+            </div>
+          ) : shots.length > 0 ? (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-medium">Résultat</h2>
+                <Badge variant="secondary" className="font-normal">
+                  {getModelSpec(result!.model)?.label ?? result!.model}
+                </Badge>
+                <Badge variant="outline" className="font-mono text-[11px]">
+                  {result!.size}
+                </Badge>
+                {result!.usedReference && (
+                  <Badge variant="outline">avec référence</Badge>
+                )}
+              </div>
+
+              <div
+                className={cn(
+                  "grid gap-3",
+                  shots.length > 1 ? "grid-cols-2" : "grid-cols-1"
+                )}
+              >
+                {shots.map((shot, i) => {
+                  const inGallery = Boolean(result!.savedToGallery?.[shot.file]);
+                  return (
+                    <figure
+                      key={shot.file}
+                      className="group relative overflow-hidden rounded-xl border bg-muted"
+                      style={{ aspectRatio: ratio }}
                     >
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        src={getImageSrc(img)}
-                        alt={prompt}
-                        className="aspect-square w-full object-cover"
+                        src={imageUrl(shot.file)}
+                        alt={result!.prompt}
+                        className="h-full w-full object-cover"
                       />
-                      <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/60 to-transparent opacity-0 transition-opacity group-hover:opacity-100">
-                        <div className="flex w-full items-center justify-end p-2">
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-8 w-8 text-white hover:text-white hover:bg-white/20"
+                      <figcaption className="pointer-events-none absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/70 via-transparent to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                        <div className="pointer-events-auto flex gap-1">
+                          <ShotAction
+                            label="Voir en grand"
+                            onClick={() => setViewerIndex(i)}
+                          >
+                            <Maximize2 className="h-4 w-4" />
+                          </ShotAction>
+                          <ShotAction
+                            label="Télécharger"
                             onClick={() =>
-                              handleDownload(getImageSrc(img), i)
+                              downloadImage(imageUrl(shot.file), shot.file)
                             }
                           >
                             <Download className="h-4 w-4" />
-                          </Button>
+                          </ShotAction>
+                          <ShotAction
+                            label={
+                              inGallery ? "Déjà en galerie" : "Ajouter à la galerie"
+                            }
+                            disabled={inGallery}
+                            onClick={() => saveShotToGallery(result!, shot.file)}
+                          >
+                            <ImageDown className="h-4 w-4" />
+                          </ShotAction>
                         </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+                      </figcaption>
+                    </figure>
+                  );
+                })}
+              </div>
+            </div>
           ) : (
-            !loading && (
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm">Exemples de styles</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-2 gap-3">
-                    {SHOWCASE.map((item) => (
-                      <div
-                        key={item.title}
-                        className={`relative aspect-square rounded-lg border ${item.border} bg-gradient-to-br ${item.gradient} flex flex-col items-center justify-center p-4 text-center`}
-                      >
-                        <ImageIcon className="h-8 w-8 mb-2 text-muted-foreground/60" />
-                        <p className="text-xs font-medium">{item.title}</p>
-                        <p className="text-[10px] text-muted-foreground mt-1">
-                          Tapez un prompt pour commencer
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            )
-          )}
-
-          {loading && (
-            <Card>
-              <CardContent className="flex flex-col items-center justify-center py-16">
-                <Loader2 className="h-10 w-10 animate-spin text-primary mb-4" />
-                <p className="text-sm text-muted-foreground">
-                  Génération en cours... Cela peut prendre quelques secondes.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </div>
-
-        {/* ─── RIGHT: Options Panel ──────────────── */}
-        <div className="space-y-3">
-          {/* Reference Image */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">Image de référence</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <input
-                ref={refInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={handleRefUpload}
-              />
-              {referenceImage ? (
-                <div className="relative">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={`data:image/png;base64,${referenceImage}`}
-                    alt="Référence"
-                    className="w-full aspect-square rounded-md object-cover"
-                  />
-                  <Button
-                    size="icon"
-                    variant="destructive"
-                    className="absolute top-1 right-1 h-6 w-6"
-                    onClick={() => setReferenceImage(null)}
-                  >
-                    <X className="h-3 w-3" />
+            <Empty className="flex-none rounded-xl border border-dashed py-14">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Sparkles />
+                </EmptyMedia>
+                <EmptyTitle>Rien de généré pour l&apos;instant</EmptyTitle>
+                <EmptyDescription>
+                  Écrivez un prompt ci-dessus. Les réglages à droite décident du
+                  modèle, du format et du nombre d&apos;images.
+                </EmptyDescription>
+              </EmptyHeader>
+              {recent.length > 0 && (
+                <EmptyContent>
+                  <Button variant="outline" size="sm" asChild className="gap-2">
+                    <Link href="/m/ai-image-gen/library">
+                      <Images className="h-4 w-4" />
+                      Voir les {recent.length} dernières générations
+                    </Link>
                   </Button>
-                </div>
-              ) : (
-                <button
-                  onClick={() => refInputRef.current?.click()}
-                  className="w-full aspect-video rounded-md border-2 border-dashed border-muted-foreground/25 flex flex-col items-center justify-center gap-1.5 transition-colors hover:border-primary/50 hover:bg-accent/50"
-                >
-                  <Upload className="h-5 w-5 text-muted-foreground" />
-                  <span className="text-xs text-muted-foreground">
-                    Télécharger une image
-                  </span>
-                </button>
+                </EmptyContent>
               )}
-            </CardContent>
-          </Card>
+            </Empty>
+          )}
 
-          {/* Model Selection */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">Modèle</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              {Object.entries(MODELS).map(([key, m]) => (
-                <button
-                  key={key}
-                  onClick={() => setModel(key)}
-                  className={`w-full flex items-center gap-2.5 rounded-lg border p-2 transition-all ${
-                    model === key
-                      ? "border-primary bg-primary/5 ring-1 ring-primary/20"
-                      : "border-border hover:border-primary/30 hover:bg-accent/50"
-                  }`}
-                >
-                  <div
-                    className={`h-9 w-9 rounded-md bg-gradient-to-br ${m.color} flex items-center justify-center shrink-0`}
-                  >
-                    <Sparkles className="h-4 w-4 text-white" />
-                  </div>
-                  <div className="text-left min-w-0">
-                    <p className="text-xs font-medium leading-none">
-                      {m.label}
-                    </p>
-                    <div className="flex gap-1 mt-1">
-                      {m.tags.map((tag) => (
-                        <Badge
-                          key={tag}
-                          variant="secondary"
-                          className="text-[9px] px-1 py-0 h-3.5"
-                        >
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                </button>
-              ))}
-            </CardContent>
-          </Card>
-
-          {/* Size */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">Taille</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Select value={size} onValueChange={setSize}>
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableSizes.map((s) => (
-                    <SelectItem key={s} value={s} className="text-xs">
-                      {s}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </CardContent>
-          </Card>
-
-          {/* Count */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">Nombre d&apos;images</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-2">
-                <Button
-                  variant={count === 1 ? "default" : "outline"}
-                  size="sm"
-                  className="flex-1 h-8 text-xs"
-                  onClick={() => setCount(1)}
-                >
-                  x1
-                </Button>
-                <Button
-                  variant={count === 4 ? "default" : "outline"}
-                  size="sm"
-                  className="flex-1 h-8 text-xs"
-                  onClick={() => setCount(4)}
-                >
-                  x4
+          {/* Reprise rapide */}
+          {recent.length > 0 && (
+            <section className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h2 className="text-sm font-medium">Générations récentes</h2>
+                <Button variant="link" size="sm" asChild className="h-auto p-0">
+                  <Link href="/m/ai-image-gen/library">Tout voir</Link>
                 </Button>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Notes */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm flex items-center gap-1.5">
-                <Palette className="h-3.5 w-3.5" />
-                Notes
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Textarea
-                placeholder="masterpiece, best quality, highly detailed..."
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                rows={2}
-                className="resize-none text-xs border-muted-foreground/20"
-              />
-              <p className="text-[10px] text-muted-foreground mt-1.5">
-                Ajoutées en pré-prompt à chaque génération
-              </p>
-            </CardContent>
-          </Card>
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                {recent.slice(0, 10).map((item) =>
+                  item.imageFiles[0] ? (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => reuse(item)}
+                      title={item.prompt}
+                      className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border transition-colors hover:border-primary"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={imageUrl(item.imageFiles[0])}
+                        alt={item.prompt}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    </button>
+                  ) : null
+                )}
+              </div>
+            </section>
+          )}
         </div>
+
+        {/* ─── Réglages ───────────────────────────────────── */}
+        <aside className="min-w-0">
+          <div className="sticky top-4 rounded-xl border bg-card p-4">
+            <FieldGroup className="gap-5">
+              <Field>
+                <FieldLabel>Modèle</FieldLabel>
+                <div className="flex flex-col gap-2">
+                  {MODELS.map((m) => (
+                    <Item
+                      key={m.id}
+                      asChild
+                      variant={model === m.id ? "muted" : "outline"}
+                      size="sm"
+                      className={cn(
+                        "cursor-pointer",
+                        model === m.id && "border-primary ring-1 ring-primary/20"
+                      )}
+                    >
+                      <button type="button" onClick={() => setModel(m.id)} className="text-left">
+                        <ItemContent>
+                          <ItemTitle className="flex items-center gap-2">
+                            {m.label}
+                            {m.tags[0] === "Recommandé" && (
+                              <Badge
+                                variant="secondary"
+                                className="h-4 px-1.5 text-[10px] font-normal"
+                              >
+                                Recommandé
+                              </Badge>
+                            )}
+                          </ItemTitle>
+                          <ItemDescription className="line-clamp-2">
+                            {m.description}
+                          </ItemDescription>
+                        </ItemContent>
+                      </button>
+                    </Item>
+                  ))}
+                </div>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ai-size">Format</FieldLabel>
+                <Select value={size} onValueChange={setSize}>
+                  <SelectTrigger id="ai-size">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {spec.sizes.map((s) => {
+                      const r = aspectRatioOf(s);
+                      const shape =
+                        r > 1.05 ? "paysage" : r < 0.95 ? "portrait" : "carré";
+                      return (
+                        <SelectItem key={s} value={s}>
+                          <span className="font-mono text-xs">{s}</span>
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            {shape}
+                          </span>
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </Field>
+
+              {spec.qualities && (
+                <Field>
+                  <FieldLabel htmlFor="ai-quality">Qualité</FieldLabel>
+                  <Select value={quality} onValueChange={setQuality}>
+                    <SelectTrigger id="ai-quality">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {spec.qualities.map((q) => (
+                        <SelectItem key={q.value} value={q.value}>
+                          {q.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FieldDescription>
+                    Une qualité plus haute coûte davantage par image.
+                  </FieldDescription>
+                </Field>
+              )}
+
+              <Field>
+                <FieldLabel>Nombre d&apos;images</FieldLabel>
+                <ButtonGroup className="w-full">
+                  {COUNT_CHOICES.map((value) => (
+                    <Button
+                      key={value}
+                      type="button"
+                      variant={count === value ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => setCount(value)}
+                      className="flex-1"
+                    >
+                      ×{value}
+                    </Button>
+                  ))}
+                </ButtonGroup>
+                {count > spec.maxBatch && (
+                  // Le contournement est réel mais facturé : le dire évite la
+                  // surprise sur la note OpenAI.
+                  <FieldDescription>
+                    {spec.label} ne rend qu&apos;une image par appel : {count}{" "}
+                    appels seront facturés.
+                  </FieldDescription>
+                )}
+              </Field>
+
+              <Field>
+                <FieldLabel>Image de référence</FieldLabel>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={handleReferencePick}
+                />
+                {reference ? (
+                  <Attachment>
+                    <AttachmentMedia variant="image">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={reference.dataUrl} alt="" />
+                    </AttachmentMedia>
+                    <AttachmentContent>
+                      <AttachmentTitle>{reference.name}</AttachmentTitle>
+                      <AttachmentDescription>
+                        {(reference.size / 1024).toFixed(0)} Ko
+                      </AttachmentDescription>
+                    </AttachmentContent>
+                    <AttachmentActions>
+                      <AttachmentAction
+                        aria-label="Retirer l'image de référence"
+                        onClick={() => setReference(null)}
+                      >
+                        <X />
+                      </AttachmentAction>
+                    </AttachmentActions>
+                  </Attachment>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={!spec.supportsReference}
+                    className="w-full justify-start gap-2 font-normal"
+                  >
+                    <Paperclip className="h-4 w-4" />
+                    Choisir une image…
+                  </Button>
+                )}
+                <FieldDescription>
+                  {spec.supportsReference
+                    ? "L'image sert de point de départ ; le prompt décrit la transformation."
+                    : `${spec.label} génère uniquement à partir de texte.`}
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ai-notes">Notes de style</FieldLabel>
+                <Textarea
+                  id="ai-notes"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  rows={2}
+                  placeholder="masterpiece, best quality…"
+                  className="resize-none text-xs"
+                />
+                <FieldDescription>
+                  Ajoutées devant chaque prompt de cette session.
+                </FieldDescription>
+              </Field>
+
+              <Button variant="ghost" size="sm" asChild className="gap-2">
+                <Link href="/m/ai-image-gen/settings">
+                  <Settings2 className="h-4 w-4" />
+                  Réglages par défaut
+                </Link>
+              </Button>
+            </FieldGroup>
+          </div>
+        </aside>
       </div>
-    </div>
+
+      <ImageViewer
+        shots={shots}
+        index={viewerIndex}
+        onIndexChange={setViewerIndex}
+        onMutate={refreshHistory}
+      />
+    </ModuleShell>
+  );
+}
+
+/** Bouton d'action en survol d'une vignette, avec libellé accessible. */
+function ShotAction({
+  label,
+  children,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="icon"
+          variant="secondary"
+          aria-label={label}
+          disabled={disabled}
+          onClick={onClick}
+          className="h-8 w-8"
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/modules/ai-image-gen/pages/library.tsx
+++ b/modules/ai-image-gen/pages/library.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Images,
+  ImageDown,
+  Search,
+  Sparkles,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type { ModuleConfig } from "@/types/modules";
+import { ModuleShell } from "../components/module-shell";
+import { ImageViewer, type Shot } from "../components/image-viewer";
+import { getModelSpec } from "../lib/models";
+import {
+  callModule,
+  formatBytes,
+  imageUrl,
+  timeAgo,
+  type HistoryItem,
+  type ModuleStats,
+} from "../lib/client";
+
+interface LibraryPageProps {
+  moduleName: string;
+  moduleConfig: ModuleConfig;
+  settings: Record<string, any>;
+}
+
+export default function LibraryPage({}: LibraryPageProps) {
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [stats, setStats] = useState<ModuleStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [query, setQuery] = useState("");
+  const [modelFilter, setModelFilter] = useState("all");
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [history, moduleStats] = await Promise.all([
+        callModule<HistoryItem[]>("getHistory", 200),
+        callModule<ModuleStats>("getStats"),
+      ]);
+      setItems(history);
+      setStats(moduleStats);
+    } catch {
+      toast.error("Chargement de la bibliothèque impossible");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return items.filter((item) => {
+      if (favoritesOnly && !item.favorite) return false;
+      if (modelFilter !== "all" && item.model !== modelFilter) return false;
+      if (!needle) return true;
+      // Les notes font partie de ce qui a produit l'image : les inclure évite
+      // qu'une recherche sur « aquarelle » rate les générations où le mot est
+      // dans le pré-prompt plutôt que dans le prompt.
+      return (
+        item.prompt.toLowerCase().includes(needle) ||
+        item.notes.toLowerCase().includes(needle)
+      );
+    });
+  }, [items, query, modelFilter, favoritesOnly]);
+
+  /** La grille montre des images, pas des générations : on aplatit les lots. */
+  const shots: Shot[] = useMemo(
+    () =>
+      filtered.flatMap((item) =>
+        item.imageFiles.map((file) => ({ item, file }))
+      ),
+    [filtered]
+  );
+
+  const availableModels = useMemo(
+    () => [...new Set(items.map((i) => i.model))],
+    [items]
+  );
+
+  const handleToggleFavorite = useCallback(
+    async (item: HistoryItem, event: React.MouseEvent) => {
+      event.stopPropagation();
+      try {
+        const res = await callModule<{ favorite: boolean }>(
+          "toggleFavorite",
+          item.id
+        );
+        setItems((prev) =>
+          prev.map((i) =>
+            i.id === item.id ? { ...i, favorite: res.favorite } : i
+          )
+        );
+      } catch {
+        toast.error("Modification impossible");
+      }
+    },
+    []
+  );
+
+  const handleSaveToGallery = useCallback(
+    async (item: HistoryItem, file: string, event: React.MouseEvent) => {
+      event.stopPropagation();
+      try {
+        const res = await callModule<{ fileName?: string }>(
+          "saveToGallery",
+          item.id,
+          file
+        );
+        toast.success(`Ajoutée à la galerie : ${res?.fileName}`);
+        load();
+      } catch (err: any) {
+        toast.error(err?.message ?? "Copie impossible");
+      }
+    },
+    [load]
+  );
+
+  const handleClearAll = useCallback(async () => {
+    try {
+      await callModule("clearHistory");
+      setItems([]);
+      load();
+      toast.success("Bibliothèque vidée");
+    } catch {
+      toast.error("Suppression impossible");
+    }
+  }, [load]);
+
+  const hasFilters = Boolean(query) || modelFilter !== "all" || favoritesOnly;
+
+  return (
+    <ModuleShell
+      current="library"
+      title="Bibliothèque"
+      description="Toutes les images produites par le module, avec leurs réglages."
+      actions={
+        <>
+          <Button size="sm" asChild className="gap-2">
+            <Link href="/m/ai-image-gen">
+              <Sparkles className="h-4 w-4" />
+              Générer
+            </Link>
+          </Button>
+          {items.length > 0 && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-2">
+                  <Trash2 className="h-4 w-4" />
+                  Tout vider
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Vider la bibliothèque ?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Les {stats?.images ?? items.length} images générées et leur
+                    historique seront supprimés du disque. Les copies déjà
+                    envoyées dans la galerie de l&apos;application, elles, sont
+                    conservées.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Annuler</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleClearAll}
+                    className="bg-destructive text-white hover:bg-destructive/90"
+                  >
+                    Supprimer
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </>
+      }
+    >
+      {/* Compteurs */}
+      {stats && stats.generations > 0 && (
+        <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[
+            { label: "Générations", value: stats.generations.toString() },
+            { label: "Images", value: stats.images.toString() },
+            { label: "En galerie", value: stats.inGallery.toString() },
+            { label: "Sur le disque", value: formatBytes(stats.diskBytes) },
+          ].map((stat) => (
+            <div key={stat.label} className="rounded-lg border bg-card px-4 py-3">
+              <dt className="text-xs text-muted-foreground">{stat.label}</dt>
+              <dd className="mt-1 text-xl font-semibold tabular-nums">
+                {stat.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {/* Filtres */}
+      {items.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <InputGroup className="w-full sm:max-w-xs">
+            <InputGroupAddon align="inline-start">
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              placeholder="Rechercher dans les prompts…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {query && (
+              <InputGroupAddon align="inline-end">
+                <InputGroupButton
+                  aria-label="Effacer la recherche"
+                  onClick={() => setQuery("")}
+                >
+                  <X />
+                </InputGroupButton>
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+
+          {availableModels.length > 1 && (
+            <Select value={modelFilter} onValueChange={setModelFilter}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tous les modèles</SelectItem>
+                {availableModels.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {getModelSpec(m)?.label ?? m}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          <Button
+            variant={favoritesOnly ? "default" : "outline"}
+            size="sm"
+            onClick={() => setFavoritesOnly((v) => !v)}
+            className="gap-1.5"
+          >
+            <Star
+              className={cn("h-3.5 w-3.5", favoritesOnly && "fill-current")}
+            />
+            Favoris
+            {stats?.favorites ? ` (${stats.favorites})` : ""}
+          </Button>
+
+          <span className="ml-auto text-sm text-muted-foreground tabular-nums">
+            {shots.length} image{shots.length > 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Grille */}
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Spinner className="h-6 w-6 text-muted-foreground" />
+        </div>
+      ) : shots.length > 0 ? (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          {shots.map((shot, index) => {
+            const inGallery = Boolean(shot.item.savedToGallery?.[shot.file]);
+            return (
+              <figure
+                key={`${shot.item.id}-${shot.file}`}
+                className="group relative aspect-square overflow-hidden rounded-xl border bg-muted"
+              >
+                <button
+                  type="button"
+                  onClick={() => setViewerIndex(index)}
+                  className="block h-full w-full"
+                  aria-label={`Ouvrir : ${shot.item.prompt}`}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={imageUrl(shot.file)}
+                    alt={shot.item.prompt}
+                    loading="lazy"
+                    className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                  />
+                </button>
+
+                {/* Actions rapides, sans passer par la visionneuse */}
+                <div className="absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    aria-label={
+                      shot.item.favorite
+                        ? "Retirer des favoris"
+                        : "Ajouter aux favoris"
+                    }
+                    onClick={(e) => handleToggleFavorite(shot.item, e)}
+                    className="h-7 w-7"
+                  >
+                    <Star
+                      className={cn(
+                        "h-3.5 w-3.5",
+                        shot.item.favorite && "fill-amber-400 text-amber-400"
+                      )}
+                    />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    aria-label={
+                      inGallery ? "Déjà en galerie" : "Ajouter à la galerie"
+                    }
+                    disabled={inGallery}
+                    onClick={(e) => handleSaveToGallery(shot.item, shot.file, e)}
+                    className="h-7 w-7"
+                  >
+                    <ImageDown className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+
+                {/* L'étoile reste visible hors survol quand elle est active,
+                    sinon un favori ne se distingue pas dans la grille. */}
+                {shot.item.favorite && (
+                  <span className="pointer-events-none absolute left-2 top-2 rounded-full bg-background/90 p-1 group-hover:opacity-0">
+                    <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                  </span>
+                )}
+
+                <figcaption className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2 pt-6 opacity-0 transition-opacity group-hover:opacity-100">
+                  <p className="line-clamp-2 text-[11px] leading-tight text-white">
+                    {shot.item.prompt}
+                  </p>
+                  <p className="mt-0.5 text-[10px] text-white/70">
+                    {timeAgo(shot.item.createdAt)}
+                  </p>
+                </figcaption>
+              </figure>
+            );
+          })}
+        </div>
+      ) : hasFilters ? (
+        <Empty className="rounded-xl border border-dashed">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Search />
+            </EmptyMedia>
+            <EmptyTitle>Aucun résultat</EmptyTitle>
+            <EmptyDescription>
+              Aucune image ne correspond à ces filtres.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setQuery("");
+                setModelFilter("all");
+                setFavoritesOnly(false);
+              }}
+            >
+              Réinitialiser les filtres
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <Empty className="rounded-xl border border-dashed">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Images />
+            </EmptyMedia>
+            <EmptyTitle>La bibliothèque est vide</EmptyTitle>
+            <EmptyDescription>
+              Les images générées depuis le Studio sont archivées ici avec le
+              prompt et les réglages qui les ont produites.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button asChild className="gap-2">
+              <Link href="/m/ai-image-gen">
+                <Sparkles className="h-4 w-4" />
+                Générer une première image
+              </Link>
+            </Button>
+          </EmptyContent>
+        </Empty>
+      )}
+
+      {/* Répartition par modèle */}
+      {stats && stats.byModel.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>Répartition :</span>
+          {stats.byModel.map((entry) => (
+            <Badge key={entry.model} variant="secondary" className="font-normal">
+              {entry.label} · {entry.count}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <ImageViewer
+        shots={shots}
+        index={viewerIndex}
+        onIndexChange={setViewerIndex}
+        onMutate={load}
+      />
+    </ModuleShell>
+  );
+}

--- a/modules/ai-image-gen/pages/settings.tsx
+++ b/modules/ai-image-gen/pages/settings.tsx
@@ -1,8 +1,39 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  KeyRound,
+  Lock,
+  ShieldCheck,
+  Sliders,
+  XCircle,
+} from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSet,
+  FieldLegend,
+} from "@/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import {
   Select,
   SelectContent,
@@ -10,28 +41,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Settings,
-  CheckCircle,
-  XCircle,
-  Loader2,
-  ArrowLeft,
-  Eye,
-  EyeOff,
-  Key,
-  Sliders,
-} from "lucide-react";
 import type { ModuleConfig } from "@/types/modules";
+import { ModuleShell } from "../components/module-shell";
+import { MODELS, getModelSpec } from "../lib/models";
+import { callModule, type SecretStatus } from "../lib/client";
 
 interface SettingsPageProps {
   moduleName: string;
@@ -39,368 +52,431 @@ interface SettingsPageProps {
   settings: Record<string, any>;
 }
 
+type ProviderKey = "openai" | "stability";
+
+const PROVIDERS: {
+  id: ProviderKey;
+  label: string;
+  field: "openai_api_key" | "stability_api_key";
+  placeholder: string;
+  help: string;
+}[] = [
+  {
+    id: "openai",
+    label: "OpenAI",
+    field: "openai_api_key",
+    placeholder: "sk-proj-…",
+    help: "Requise pour GPT Image 1 et DALL-E 3.",
+  },
+  {
+    id: "stability",
+    label: "Stability AI",
+    field: "stability_api_key",
+    placeholder: "sk-…",
+    help: "Requise pour Stable Diffusion XL.",
+  },
+];
+
 export default function SettingsPage({
   moduleName,
   settings: initialSettings,
 }: SettingsPageProps) {
-  const [settings, setSettings] = useState(initialSettings);
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [testResult, setTestResult] = useState<{
-    provider: string;
-    success: boolean;
-    message: string;
-  } | null>(null);
-  const [testing, setTesting] = useState<string | null>(null);
-  const [showOpenAI, setShowOpenAI] = useState(false);
-  const [showStability, setShowStability] = useState(false);
+  const [settings, setSettings] = useState<Record<string, any>>(initialSettings);
+  const [keys, setKeys] = useState<Record<string, SecretStatus> | null>(null);
 
-  // Refetch settings on mount
+  /** Saisie en cours, non encore enregistrée. Vide = la clé stockée est conservée. */
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+  const [testing, setTesting] = useState<string | null>(null);
+  const [tests, setTests] = useState<
+    Record<string, { success: boolean; message: string }>
+  >({});
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [savingPrefs, setSavingPrefs] = useState(false);
+
+  const loadKeys = useCallback(() => {
+    callModule<Record<string, SecretStatus>>("getSecretsStatus")
+      .then(setKeys)
+      .catch(() => setKeys(null));
+  }, []);
+
   useEffect(() => {
+    loadKeys();
     fetch(`/api/modules/${moduleName}/settings`)
       .then((r) => r.json())
-      .then((data) => {
-        if (data.settings) setSettings(data.settings);
-      })
+      .then((data) => data?.settings && setSettings(data.settings))
       .catch(() => {});
-  }, [moduleName]);
+  }, [moduleName, loadKeys]);
 
-  const handleSave = async () => {
-    setSaving(true);
-    setSaved(false);
+  const defaultModel = getModelSpec(settings.default_model || "gpt-image-1");
+
+  // ─── Clés API ───────────────────────────────────────────────
+
+  const handleSaveKey = async (field: string, id: ProviderKey) => {
+    setSavingKey(id);
+    try {
+      await callModule("saveSecrets", { [field]: drafts[field] ?? "" });
+      setDrafts((prev) => ({ ...prev, [field]: "" }));
+      setTests((prev) => ({ ...prev, [id]: undefined as any }));
+      loadKeys();
+      toast.success(
+        drafts[field] ? "Clé enregistrée" : "Clé supprimée"
+      );
+    } catch (error: any) {
+      toast.error(error?.message ?? "Enregistrement impossible");
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const handleTest = async (id: ProviderKey) => {
+    setTesting(id);
+    try {
+      const result = await callModule<{ success: boolean; message: string }>(
+        "testConnection",
+        id
+      );
+      setTests((prev) => ({ ...prev, [id]: result }));
+    } catch (error: any) {
+      setTests((prev) => ({
+        ...prev,
+        [id]: { success: false, message: error?.message ?? "Erreur" },
+      }));
+    } finally {
+      setTesting(null);
+    }
+  };
+
+  // ─── Préférences ────────────────────────────────────────────
+
+  const updateSetting = (key: string, value: unknown) =>
+    setSettings((prev) => ({ ...prev, [key]: value }));
+
+  const handleSavePrefs = async () => {
+    setSavingPrefs(true);
     try {
       const res = await fetch(`/api/modules/${moduleName}/settings`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings }),
       });
-      if (res.ok) {
-        setSaved(true);
-        setTimeout(() => setSaved(false), 3000);
-      }
-    } catch {
-      // ignore
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success("Préférences enregistrées");
+    } catch (error: any) {
+      toast.error(error?.message ?? "Enregistrement impossible");
     } finally {
-      setSaving(false);
+      setSavingPrefs(false);
     }
-  };
-
-  const handleTestConnection = async (provider: "openai" | "stability") => {
-    // Save settings first so the server reads the latest key
-    await fetch(`/api/modules/${moduleName}/settings`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ settings }),
-    });
-
-    setTesting(provider);
-    setTestResult(null);
-    try {
-      const res = await fetch("/api/modules/call-function", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          moduleName: "ai-image-gen",
-          functionName: "testConnection",
-          args: [provider],
-        }),
-      });
-      const result = await res.json();
-      if (result.success && result.data) {
-        setTestResult({ provider, ...result.data });
-      } else {
-        setTestResult({
-          provider,
-          success: false,
-          message: result.error || "Erreur",
-        });
-      }
-    } catch {
-      setTestResult({
-        provider,
-        success: false,
-        message: "Erreur réseau",
-      });
-    } finally {
-      setTesting(null);
-    }
-  };
-
-  const updateSetting = (key: string, value: any) => {
-    setSettings((prev: any) => ({ ...prev, [key]: value }));
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <a href="/m/ai-image-gen">
-            <ArrowLeft className="h-4 w-4" />
-          </a>
-        </Button>
-        <div>
-          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
-            Configuration
-          </h1>
-          <p className="text-muted-foreground">
-            Paramètres du module AI Image Generation
-          </p>
-        </div>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* API Keys */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Key className="h-5 w-5" />
+    <ModuleShell
+      current="settings"
+      title="Configuration"
+      description="Clés d'accès aux API et valeurs par défaut du Studio."
+    >
+      <div className="grid gap-5 lg:grid-cols-2">
+        {/* ─── Clés API ─────────────────────────────────── */}
+        <section className="rounded-xl border bg-card p-5">
+          <FieldSet>
+            <FieldLegend className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4" />
               Clés API
-            </CardTitle>
-            <CardDescription>
-              Configurez vos clés API pour chaque provider
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* OpenAI */}
-            <div className="space-y-2.5">
-              <Label className="text-sm font-medium">Clé API OpenAI</Label>
-              <div className="relative">
-                <Input
-                  type={showOpenAI ? "text" : "password"}
-                  placeholder="sk-proj-..."
-                  value={settings.openai_api_key || ""}
-                  onChange={(e) =>
-                    updateSetting("openai_api_key", e.target.value)
-                  }
-                  className="pr-10 bg-muted/50 border-muted-foreground/20 font-mono text-xs"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                  onClick={() => setShowOpenAI(!showOpenAI)}
-                >
-                  {showOpenAI ? (
-                    <EyeOff className="h-4 w-4 text-muted-foreground" />
-                  ) : (
-                    <Eye className="h-4 w-4 text-muted-foreground" />
-                  )}
-                </Button>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleTestConnection("openai")}
-                  disabled={testing !== null || !settings.openai_api_key}
-                >
-                  {testing === "openai" && (
-                    <Loader2 className="mr-2 h-3 w-3 animate-spin" />
-                  )}
-                  Tester la connexion
-                </Button>
-                {testResult?.provider === "openai" && (
-                  <span
-                    className={`inline-flex items-center gap-1 text-xs ${
-                      testResult.success
-                        ? "text-green-600 dark:text-green-400"
-                        : "text-destructive"
-                    }`}
-                  >
-                    {testResult.success ? (
-                      <CheckCircle className="h-3 w-3" />
-                    ) : (
-                      <XCircle className="h-3 w-3" />
-                    )}
-                    {testResult.message}
-                  </span>
-                )}
-              </div>
-            </div>
+            </FieldLegend>
 
-            {/* Stability */}
-            <div className="space-y-2.5">
-              <Label className="text-sm font-medium">
-                Clé API Stability AI
-              </Label>
-              <div className="relative">
-                <Input
-                  type={showStability ? "text" : "password"}
-                  placeholder="sk-..."
-                  value={settings.stability_api_key || ""}
-                  onChange={(e) =>
-                    updateSetting("stability_api_key", e.target.value)
-                  }
-                  className="pr-10 bg-muted/50 border-muted-foreground/20 font-mono text-xs"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-                  onClick={() => setShowStability(!showStability)}
-                >
-                  {showStability ? (
-                    <EyeOff className="h-4 w-4 text-muted-foreground" />
-                  ) : (
-                    <Eye className="h-4 w-4 text-muted-foreground" />
-                  )}
-                </Button>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleTestConnection("stability")}
-                  disabled={testing !== null || !settings.stability_api_key}
-                >
-                  {testing === "stability" && (
-                    <Loader2 className="mr-2 h-3 w-3 animate-spin" />
-                  )}
-                  Tester la connexion
-                </Button>
-                {testResult?.provider === "stability" && (
-                  <span
-                    className={`inline-flex items-center gap-1 text-xs ${
-                      testResult.success
-                        ? "text-green-600 dark:text-green-400"
-                        : "text-destructive"
-                    }`}
-                  >
-                    {testResult.success ? (
-                      <CheckCircle className="h-3 w-3" />
-                    ) : (
-                      <XCircle className="h-3 w-3" />
-                    )}
-                    {testResult.message}
-                  </span>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Defaults */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Sliders className="h-5 w-5" />
-              Paramètres par défaut
-            </CardTitle>
-            <CardDescription>
-              Valeurs par défaut pour la génération
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                Provider par défaut
-              </Label>
-              <Select
-                value={settings.provider || "openai"}
-                onValueChange={(val) => updateSetting("provider", val)}
-              >
-                <SelectTrigger className="bg-muted/50 border-muted-foreground/20">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="openai">OpenAI</SelectItem>
-                  <SelectItem value="stability">Stability AI</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                Modèle par défaut
-              </Label>
-              <Select
-                value={settings.default_model || "dall-e-3"}
-                onValueChange={(val) => updateSetting("default_model", val)}
-              >
-                <SelectTrigger className="bg-muted/50 border-muted-foreground/20">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="dall-e-3">DALL-E 3</SelectItem>
-                  <SelectItem value="dall-e-2">DALL-E 2</SelectItem>
-                  <SelectItem value="stable-diffusion-xl">
-                    Stable Diffusion XL
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">
-                Taille par défaut
-              </Label>
-              <Select
-                value={settings.default_size || "1024x1024"}
-                onValueChange={(val) => updateSetting("default_size", val)}
-              >
-                <SelectTrigger className="bg-muted/50 border-muted-foreground/20">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="1024x1024">1024 x 1024</SelectItem>
-                  <SelectItem value="1024x1792">1024 x 1792</SelectItem>
-                  <SelectItem value="1792x1024">1792 x 1024</SelectItem>
-                  <SelectItem value="512x512">512 x 512</SelectItem>
-                  <SelectItem value="256x256">256 x 256</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">Notes pré-prompt</Label>
-              <Textarea
-                placeholder="masterpiece, best quality, highly detailed..."
-                value={settings.notes_preprompt || ""}
-                onChange={(e) =>
-                  updateSetting("notes_preprompt", e.target.value)
-                }
-                rows={2}
-                className="resize-none text-xs bg-muted/50 border-muted-foreground/20"
-              />
-              <p className="text-[11px] text-muted-foreground">
-                Ces notes sont ajoutées automatiquement avant chaque prompt
+            <div className="mb-4 flex items-start gap-2.5 rounded-lg bg-muted/60 px-3 py-2.5">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+              <p className="text-xs leading-5 text-muted-foreground">
+                Les clés sont écrites dans{" "}
+                <code className="rounded bg-background px-1 py-0.5 font-mono text-[11px]">
+                  modules/ai-image-gen/data/secrets.json
+                </code>
+                , en dehors du dépôt git. Les variables{" "}
+                <code className="rounded bg-background px-1 py-0.5 font-mono text-[11px]">
+                  OPENAI_API_KEY
+                </code>{" "}
+                et{" "}
+                <code className="rounded bg-background px-1 py-0.5 font-mono text-[11px]">
+                  STABILITY_API_KEY
+                </code>{" "}
+                priment si elles existent.
               </p>
             </div>
 
-            <div className="flex items-center justify-between rounded-lg border border-muted-foreground/20 p-3">
-              <Label
-                htmlFor="save-gallery"
-                className="text-sm font-medium cursor-pointer"
-              >
-                Sauvegarder dans la galerie
-              </Label>
-              <Switch
-                id="save-gallery"
-                checked={settings.save_to_gallery ?? true}
-                onCheckedChange={(val) =>
-                  updateSetting("save_to_gallery", val)
-                }
-              />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+            <FieldGroup className="gap-6">
+              {PROVIDERS.map((provider) => {
+                const status = keys?.[provider.id];
+                const fromEnv = status?.fromEnv;
+                const draft = drafts[provider.field] ?? "";
+                const test = tests[provider.id];
 
-      {/* Save button */}
-      <div className="flex items-center gap-3">
-        <Button onClick={handleSave} disabled={saving}>
-          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          Sauvegarder les paramètres
-        </Button>
-        {saved && (
-          <span className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
-            <CheckCircle className="h-4 w-4" />
-            Paramètres sauvegardés
-          </span>
-        )}
+                return (
+                  <Field key={provider.id}>
+                    <FieldLabel
+                      htmlFor={`key-${provider.id}`}
+                      className="flex items-center gap-2"
+                    >
+                      {provider.label}
+                      {status?.configured && (
+                        <Badge
+                          variant="secondary"
+                          className="h-5 gap-1 px-1.5 text-[10px] font-normal"
+                        >
+                          {fromEnv ? (
+                            <>
+                              <Lock className="h-2.5 w-2.5" />
+                              variable d&apos;environnement
+                            </>
+                          ) : (
+                            status.hint
+                          )}
+                        </Badge>
+                      )}
+                    </FieldLabel>
+
+                    {fromEnv ? (
+                      // Saisir une clé ici serait sans effet : l'environnement
+                      // l'emporte à la lecture. Mieux vaut le dire.
+                      <FieldDescription>
+                        Définie par l&apos;environnement du serveur. Retirez la
+                        variable pour pouvoir la gérer depuis cette page.
+                      </FieldDescription>
+                    ) : (
+                      <>
+                        <InputGroup>
+                          <InputGroupInput
+                            id={`key-${provider.id}`}
+                            type={revealed[provider.field] ? "text" : "password"}
+                            placeholder={
+                              status?.configured
+                                ? "Laisser vide pour conserver la clé actuelle"
+                                : provider.placeholder
+                            }
+                            value={draft}
+                            onChange={(e) =>
+                              setDrafts((prev) => ({
+                                ...prev,
+                                [provider.field]: e.target.value,
+                              }))
+                            }
+                            className="font-mono text-xs"
+                          />
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              aria-label={
+                                revealed[provider.field]
+                                  ? "Masquer la clé"
+                                  : "Afficher la clé"
+                              }
+                              onClick={() =>
+                                setRevealed((prev) => ({
+                                  ...prev,
+                                  [provider.field]: !prev[provider.field],
+                                }))
+                              }
+                            >
+                              {revealed[provider.field] ? <EyeOff /> : <Eye />}
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
+                        <FieldDescription>{provider.help}</FieldDescription>
+                      </>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {!fromEnv && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={
+                            savingKey === provider.id ||
+                            (!draft && !status?.configured)
+                          }
+                          onClick={() =>
+                            handleSaveKey(provider.field, provider.id)
+                          }
+                        >
+                          {savingKey === provider.id && (
+                            <Spinner className="mr-1.5 h-3 w-3" />
+                          )}
+                          {draft
+                            ? "Enregistrer"
+                            : status?.configured
+                              ? "Supprimer la clé"
+                              : "Enregistrer"}
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={testing !== null || !status?.configured}
+                        onClick={() => handleTest(provider.id)}
+                      >
+                        {testing === provider.id && (
+                          <Spinner className="mr-1.5 h-3 w-3" />
+                        )}
+                        Tester
+                      </Button>
+                      {test && (
+                        <span
+                          className={
+                            test.success
+                              ? "inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400"
+                              : "inline-flex items-center gap-1 text-xs text-destructive"
+                          }
+                        >
+                          {test.success ? (
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                          ) : (
+                            <XCircle className="h-3.5 w-3.5" />
+                          )}
+                          {test.message}
+                        </span>
+                      )}
+                    </div>
+                  </Field>
+                );
+              })}
+            </FieldGroup>
+          </FieldSet>
+        </section>
+
+        {/* ─── Valeurs par défaut ───────────────────────── */}
+        <section className="rounded-xl border bg-card p-5">
+          <FieldSet>
+            <FieldLegend className="flex items-center gap-2">
+              <Sliders className="h-4 w-4" />
+              Valeurs par défaut
+            </FieldLegend>
+
+            <FieldGroup className="gap-5">
+              <Field>
+                <FieldLabel htmlFor="default-model">Modèle</FieldLabel>
+                <Select
+                  value={settings.default_model || "gpt-image-1"}
+                  onValueChange={(v) => {
+                    updateSetting("default_model", v);
+                    // Les tailles diffèrent d'un modèle à l'autre : conserver
+                    // l'ancienne enregistrerait un défaut invalide.
+                    const spec = getModelSpec(v);
+                    if (spec && !spec.sizes.includes(settings.default_size)) {
+                      updateSetting("default_size", spec.sizes[0]);
+                    }
+                    if (
+                      spec?.qualities &&
+                      !spec.qualities.some(
+                        (q) => q.value === settings.default_quality
+                      )
+                    ) {
+                      updateSetting("default_quality", spec.qualities[0].value);
+                    }
+                  }}
+                >
+                  <SelectTrigger id="default-model">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MODELS.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {defaultModel && (
+                  <FieldDescription>{defaultModel.description}</FieldDescription>
+                )}
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="default-size">Format</FieldLabel>
+                <Select
+                  value={settings.default_size || "1024x1024"}
+                  onValueChange={(v) => updateSetting("default_size", v)}
+                >
+                  <SelectTrigger id="default-size">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(defaultModel?.sizes ?? ["1024x1024"]).map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+
+              {defaultModel?.qualities && (
+                <Field>
+                  <FieldLabel htmlFor="default-quality">Qualité</FieldLabel>
+                  <Select
+                    value={
+                      settings.default_quality || defaultModel.qualities[0].value
+                    }
+                    onValueChange={(v) => updateSetting("default_quality", v)}
+                  >
+                    <SelectTrigger id="default-quality">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {defaultModel.qualities.map((q) => (
+                        <SelectItem key={q.value} value={q.value}>
+                          {q.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              )}
+
+              <Field>
+                <FieldLabel htmlFor="default-notes">Notes de style</FieldLabel>
+                <Textarea
+                  id="default-notes"
+                  rows={3}
+                  placeholder="masterpiece, best quality, highly detailed…"
+                  value={settings.notes_preprompt || ""}
+                  onChange={(e) =>
+                    updateSetting("notes_preprompt", e.target.value)
+                  }
+                  className="resize-none text-xs"
+                />
+                <FieldDescription>
+                  Placées devant chaque prompt. Le Studio les pré-remplit et
+                  permet de les ajuster au coup par coup.
+                </FieldDescription>
+              </Field>
+
+              <Separator />
+
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <FieldLabel htmlFor="save-gallery">
+                    Envoyer dans la galerie
+                  </FieldLabel>
+                  <FieldDescription>
+                    Chaque image générée est copiée dans les uploads de
+                    l&apos;application et devient visible dans la galerie.
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="save-gallery"
+                  checked={Boolean(settings.save_to_gallery)}
+                  onCheckedChange={(v) => updateSetting("save_to_gallery", v)}
+                />
+              </Field>
+            </FieldGroup>
+          </FieldSet>
+
+          <div className="mt-6 flex justify-end">
+            <Button onClick={handleSavePrefs} disabled={savingPrefs}>
+              {savingPrefs && <Spinner className="mr-2 h-4 w-4" />}
+              Enregistrer les préférences
+            </Button>
+          </div>
+        </section>
       </div>
-    </div>
+    </ModuleShell>
   );
 }


### PR DESCRIPTION
Reprise complète du module `ai-image-gen`. En ouvrant le capot, trois fonctionnalités présentes dans l'interface ne faisaient **rien du tout**.

## Fonctions mortes

**Image de référence.** Le fichier était lu, encodé en base64, envoyé au serveur — puis jamais transmis à aucune API. `referenceImageB64` n'apparaissait nulle part dans les adaptateurs. Elle passe désormais par `/v1/images/edits` (multipart) avec GPT Image 1 ; une référence donnée à un modèle qui n'en gère pas est refusée avec un message au lieu d'être ignorée.

**Copie vers la galerie.** Le réglage `save_to_gallery` existait dans l'interface, s'enregistrait, et n'était lu par aucun code — zéro occurrence dans le moteur. Les images générées ne rejoignaient jamais la galerie. Vérifié après correction : le fichier atterrit dans `uploads/` et `/api/files/<nom>` répond 200.

**Erreurs silencieuses — le défaut de fond.** `callModuleFunction` interceptait toute exception et renvoyait `null`, que la route emballait en `success: true`. Un échec était donc indiscernable d'un succès sans résultat. Sans clé API, l'outil ne disait rien : il ne se passait simplement rien. Corrigé aux deux niveaux.

Ce dernier point concerne **tous les modules**, pas seulement celui-ci — aucun ne pouvait signaler un échec. Un seul appelant existe (`app/api/modules/call-function/route.ts`), l'impact est donc contenu.

Vérifié en conditions réelles :

| Cas | Message remonté |
|---|---|
| Sans clé | « Aucune clé OpenAI enregistrée. Ouvrez la configuration… » |
| Prompt vide | « Le prompt est vide. » |
| Modèle inconnu | « Modèle inconnu : nope-9000 » |
| Référence + DALL-E 3 | « DALL-E 3 ne sait pas partir d'une image de référence » |

## Clés API hors du dépôt

`module.json` est versionné et c'est lui qui stockait `openai_api_key` : enregistrer une clé la plaçait dans un fichier suivi par git. Rien n'a fuité historiquement (les champs étaient vides), mais le piège était armé.

Les clés vont maintenant dans `modules/ai-image-gen/data/secrets.json` (mode `0600`), avec `modules/*/data/` ajouté au `.gitignore` et `OPENAI_API_KEY` / `STABILITY_API_KEY` prioritaires pour le déploiement en conteneur. L'interface n'affiche qu'une empreinte (`••••••••a4f2`), jamais la clé.

## Interface : trois pages au lieu d'une

- **Studio** — prompt en `InputGroup`, rail de réglages construit depuis le catalogue de modèles, donc plus aucune taille proposée qu'une API refuserait. Pendant la génération, des squelettes au ratio demandé réservent la place : la page ne saute plus.
- **Bibliothèque** (nouvelle) — l'historique tenait dans une colonne de 220 px sans aucun moyen d'agrandir une image. Grille uniforme, recherche dans les prompts *et* les notes, filtre par modèle, favoris, compteurs, visionneuse plein écran avec navigation clavier et métadonnées.
- **Configuration** — refaite en `Field` ; chaque clé s'enregistre indépendamment de l'autre.

Les trois pages partagent une barre de navigation : passer de l'une à l'autre n'était pas possible avant.

Les « Exemples de styles » — quatre rectangles dégradés vides qui occupaient le plus gros de l'écran pour afficher « Tapez un prompt » — laissent place à un véritable état vide.

Modèles à jour : `gpt-image-1` remplace DALL-E 2. Un lot de 4 sur DALL-E 3 (qui ne rend qu'une image par appel) annonce désormais que 4 appels seront facturés.

## Composants

`attachment` ajouté depuis le registre shadcn — il correspond exactement à l'image de référence et ne tire que `radix-ui`, déjà présent. `combobox` aurait ajouté `@base-ui/react` pour trois modèles : écarté. `empty`, `field`, `item`, `input-group`, `button-group`, `kbd`, `spinner` étaient déjà installés mais inutilisés.

## Vérifications

- `tsc --noEmit` : 4 erreurs, les mêmes qu'avant (`modules/hello-world/index.ts:18`)
- `next build` : OK
- 0 erreur console sur les trois pages
- Favoris, copie galerie, suppression unitaire, statistiques, visionneuse et chemins d'erreur testés en conditions réelles via l'API du module

**Non vérifié :** une génération réelle. Sans clé API, le code des providers (paramètres `gpt-image-1`, endpoint `/images/edits`) est écrit d'après le contrat des API mais n'a jamais été exercé en vrai.