### PR TITLE
Persister les données runtime des modules entre les rebuilds Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ data/*.db*
 # `secrets.json` (clés API). `module.json` reste versionné, lui, car c'est le
 # manifeste du module — d'où la séparation des deux.
 modules/*/data/
+# Même contenu, côté hôte, quand il est monté dans le conteneur.
+/module-data
 
 # uploads
 /uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - ./config:/app/config
       - ./uploads:/app/uploads:delegated
       - ./data:/app/data
+      # Données runtime des modules (images générées, historiques, secrets.json).
+      # `modules/` est cuit dans l'image : sans ce montage, tout serait perdu à
+      # chaque rebuild. Les clés API peuvent aussi passer par .env, qui prime.
+      - ./module-data/ai-image-gen:/app/modules/ai-image-gen/data
       - next-cache:/app/.next/cache
 
 volumes:


### PR DESCRIPTION
`modules/` est cuit dans l'image et n'était monté nulle part. Les images générées par `ai-image-gen`, son historique et son `secrets.json` auraient donc disparu à **chaque redéploiement** — ce qui rend le module inutilisable en production.

Ajout d'un montage `./module-data/ai-image-gen:/app/modules/ai-image-gen/data`, aligné sur le traitement déjà appliqué à `config/`, `uploads/` et `data/`.

Les clés API peuvent alternativement venir de `.env` (`OPENAI_API_KEY`, `STABILITY_API_KEY`), qui prime sur le fichier — c'est la voie recommandée en conteneur, puisqu'elle survit même à la perte du volume.

Le dossier hôte `module-data/` est ajouté au `.gitignore`.