### PR TITLE
fix(docker) : liens localhost dans la galerie — NEXT_PUBLIC_* absentes du build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,36 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/modules ./modules
 COPY . .
 
-# Valeurs de remplacement : Next évalue les variables NEXT_PUBLIC_* à la
-# compilation. Les vraies valeurs sont réinjectées à l'exécution par le compose.
+# Les NEXT_PUBLIC_* sont inlinées dans le bundle client AU MOMENT DU BUILD.
+# Les définir dans le compose ne sert qu'au code serveur : le navigateur, lui,
+# reçoit la valeur figée ici. Comme `.env` est exclu de l'image (il contient
+# AUTH_SECRET), ces valeurs doivent arriver par --build-arg, sinon le client
+# retombe sur les valeurs par défaut du code — c'est ce qui avait produit des
+# liens « http://localhost:3000/api/files/... » copiés depuis la galerie.
+#
+# Ces trois valeurs sont publiques par nature : elles partent dans le bundle
+# livré au navigateur. Aucun secret ne doit passer par un ARG, qui reste
+# lisible dans l'historique de l'image.
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_IMAGE_DOMAIN
+ARG NEXT_PUBLIC_APP_DOMAIN
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV NEXT_PUBLIC_IMAGE_DOMAIN=${NEXT_PUBLIC_IMAGE_DOMAIN}
+ENV NEXT_PUBLIC_APP_DOMAIN=${NEXT_PUBLIC_APP_DOMAIN}
+
+# Échec immédiat plutôt qu'une image qui démarre en distribuant de mauvaises
+# URL. L'oubli précédent n'était visible qu'en cliquant « copier le lien » en
+# production.
+RUN test -n "$NEXT_PUBLIC_API_URL" -a -n "$NEXT_PUBLIC_IMAGE_DOMAIN" -a -n "$NEXT_PUBLIC_APP_DOMAIN" \
+    || { echo "ERREUR: NEXT_PUBLIC_API_URL, NEXT_PUBLIC_IMAGE_DOMAIN et NEXT_PUBLIC_APP_DOMAIN doivent être fournis via --build-arg (le compose les lit depuis .env)."; exit 1; }
+
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN bun run build
+
+# Garde-fou : si une URL de repli s'est glissée dans le bundle client, c'est que
+# l'inlining n'a pas pris. Mieux vaut casser le build que livrer ça.
+RUN ! grep -rqF "localhost:3000/api/files" .next/static \
+    || { echo "ERREUR: des URL localhost sont figées dans le bundle client — NEXT_PUBLIC_IMAGE_DOMAIN n'a pas été pris en compte."; exit 1; }
 
 # Image d'exécution
 FROM base AS runner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,13 @@ services:
     build:
       context: .
       target: runner
+      # Indispensable, pas redondant avec le bloc `environment` : Next fige les
+      # NEXT_PUBLIC_* dans le bundle client pendant `bun run build`. Sans ces
+      # args, le navigateur reçoit les valeurs de repli du code.
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3000}
+        NEXT_PUBLIC_IMAGE_DOMAIN: ${NEXT_PUBLIC_IMAGE_DOMAIN:-img.ascencia.re}
+        NEXT_PUBLIC_APP_DOMAIN: ${NEXT_PUBLIC_APP_DOMAIN:-sxm.ascencia.re}
     ports:
       - "${PORT:-3000}:${PORT:-3000}"
     env_file:


### PR DESCRIPTION
## Le bug

En production, « copier le lien » depuis la galerie produisait `http://localhost:3000/api/files/<fichier>.png` au lieu de l'URL réelle.

## L'origine

Une régression que j'ai introduite. Depuis `2470a56`, `.env` est exclu de l'image pour ne plus y laisser fuiter `AUTH_SECRET` — mais ce fichier était aussi la **seule source des variables `NEXT_PUBLIC_*` pendant `bun run build`**.

Next fige ces variables dans le bundle livré au navigateur **à la compilation**. Les redéfinir dans le bloc `environment` du compose ne sert qu'au code serveur. `getGalleryImageUrl()` ne voyait donc plus `NEXT_PUBLIC_IMAGE_DOMAIN` et retombait sur son repli.

Constaté dans l'image livrée :

| Chaîne dans `.next/static` | Avant | Après |
|---|---|---|
| `localhost:3000/api/files` | présente | **0** |
| `img.ascencia.re` | absente | **2 fichiers** |
| `sxm.ascencia.re` | 1 | **3 fichiers** |

Le commentaire du Dockerfile affirmait que les valeurs étaient « réinjectées à l'exécution par le compose ». C'est faux pour un bundle client, et c'est cette affirmation qui a laissé passer la régression. Il est corrigé.

## Étendue

Bien au-delà du bouton copier : **13 appels à `getGalleryImageUrl` dans 8 fichiers**.

| Fichier | Ce qui était cassé |
|---|---|
| `grid-view.tsx`, `list-view.tsx` | copier le lien |
| `file-card.tsx`, `list-item-card.tsx`, `selectable-list-item-card.tsx` | ouvrir dans un onglet |
| `file-context-menu.tsx` | ouvrir depuis le clic droit |
| `file-viewer.tsx` | URL affichée, 3 boutons copier, 2 liens |

## Le correctif

Trois `ARG`/`ENV` dans l'étage builder, alimentés par `build.args` du compose, lui-même interpolé depuis le `.env` de l'hôte. **`.env` reste hors de l'image** : la fuite d'`AUTH_SECRET` reste colmatée.

Ces trois valeurs sont publiques par construction puisqu'elles partent dans le bundle. Aucun secret ne doit transiter par un `ARG`, qui reste lisible dans l'historique de l'image.

## Garde-fous

Pour que l'oubli ne puisse plus être silencieux :

1. Le build échoue si l'une des trois variables est vide.
2. Le build échoue si `localhost:3000/api/files` se retrouve dans `.next/static`.

Les deux sont vérifiés : sans args le build s'arrête sur le premier contrôle, avec args le bundle est propre. Contrôlé également qu'aucun `.env` ni `AUTH_SECRET` n'entre dans l'image.