### PR TITLE
chore(mobile): préparer la release 1.0.0

### DIFF
--- a/sharex-mobile/CHANGELOG.md
+++ b/sharex-mobile/CHANGELOG.md
@@ -18,6 +18,33 @@ politique complète se trouve dans
 
 ### Security
 
-> Aucun tag de release mobile n'existe encore. La version `1.0.0` actuellement
-> présente dans les manifestes n'est pas considérée comme publiée tant que la
-> release correspondante n'a pas été préparée et validée explicitement.
+## [1.0.0] - 2026-08-13
+
+### Added
+
+- Nouvelle application mobile ShareX Manager avec onboarding, galerie et flux
+  d'envoi unifié pour les images et les fichiers.
+- Partage Android natif d'un ou plusieurs éléments directement depuis la
+  galerie ou le gestionnaire de fichiers.
+- Envoi automatique optionnel des captures d'écran, avec détection en
+  arrière-plan, progression, notification et synchronisation avec les éléments
+  récents.
+- Écran d'envoi multiple affichant la progression de chaque élément, son état
+  final et les actions de copie associées.
+- Visionneuse plein écran sur fond noir permettant de parcourir les images et
+  d'accéder à leurs informations et actions.
+
+### Changed
+
+- Refonte complète de l'identité visuelle, de la navigation, de l'onboarding,
+  des icônes et du splash screen.
+- Adaptation des écrans aux zones sûres Android afin d'éviter le chevauchement
+  avec les commandes système.
+
+### Fixed
+
+- Affichage dans la galerie des images immédiatement après leur envoi.
+- Synchronisation des captures envoyées automatiquement avec la liste des
+  éléments récents.
+- Fiabilité de la détection des captures lorsque l'application revient au
+  premier plan ou fonctionne en arrière-plan.


### PR DESCRIPTION
## Release mobile 1.0.0

- finalise les notes utilisateur de la première release mobile ;
- conserve une section Unreleased vide pour la suite ;
- prépare le commit qui recevra le tag annoté mobile-v1.0.0.

## Validation

- validateur exécuté pour le tag mobile-v1.0.0 ;
- versions app.json, package.json et package-lock.json cohérentes ;
- changelog daté et notes de release validées.