### PR TITLE
fix(ci): corriger les chemins des assets mobile

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -177,11 +177,11 @@ jobs:
         run: |
           release_arguments=(
             "$GITHUB_REF_NAME"
-            "release-assets/${{ needs.build-android.outputs.artifact_name }}"
-            "release-assets/${{ needs.build-android.outputs.checksum_name }}"
+            "release-assets/sharex-mobile/dist/${{ needs.build-android.outputs.artifact_name }}"
+            "release-assets/sharex-mobile/dist/${{ needs.build-android.outputs.checksum_name }}"
             --verify-tag
             --title "${{ needs.build-android.outputs.release_title }}"
-            --notes-file release-assets/RELEASE_NOTES.md
+            --notes-file release-assets/dist/RELEASE_NOTES.md
           )
           if [[ "${{ needs.build-android.outputs.prerelease }}" == "true" ]]; then
             release_arguments+=(--prerelease)


### PR DESCRIPTION
## Correction

Le job de publication télécharge correctement l’archive de release, mais celle-ci conserve les chemins sharex-mobile/dist et dist. La commande gh release cherchait les fichiers à la racine et échouait avec no matches found.

Cette PR aligne les trois chemins de publication sur la structure réelle de l’archive.

## Validation

- actionlint ;
- vérification des trois chemins contre l’artefact réel du run 31680781556 ;
- somme SHA-256 et signature APK déjà validées par le job de build.